### PR TITLE
Allow call to Pubnub.publish() without a callback parameter

### DIFF
--- a/python-tornado/Pubnub.py
+++ b/python-tornado/Pubnub.py
@@ -67,7 +67,8 @@ class Pubnub(PubnubCoreAsync):
         #print self.headers
         request = tornado.httpclient.HTTPRequest( url, 'GET', self.headers, connect_timeout=310, request_timeout=310 ) 
         def responseCallback(response):
-            callback(eval(response._get_body()))
+            if callback:
+                callback(eval(response._get_body()))
         
         self.http.fetch(
             request,


### PR DESCRIPTION
Currently, the _request method assumes a callable callback parameter.  However, the Pubnub API (and general pub/sub semantics) allows calls to publish() without a callback (see e.g. common/PubnubBase.py:154-158).  Thus _request can be invoked with callback=None.  This raises a "TypeError: 'NoneType' object is not callable" exception at line 70

The proposed change will only invoke the callback when callback != None
