### PR TITLE
Add keyword argument 'blocking' to publish()

### DIFF
--- a/common/PubnubBase.py
+++ b/common/PubnubBase.py
@@ -83,7 +83,7 @@ class PubnubBase(object):
         return message
 
 
-    def publish( self, args ) :
+    def publish( self, args, blocking = True ) :
         """
         #**
         #* Publish
@@ -91,6 +91,7 @@ class PubnubBase(object):
         #* Send a message to a channel.
         #*
         #* @param array args with channel and message.
+        #* @param bool blocking If False the call will return directly with no data
         #* @return array success information.
         #**
 
@@ -131,7 +132,7 @@ class PubnubBase(object):
             channel,
             '0',
             message
-        ]}, callback)
+        ]}, callback, blocking)
     
     def presence( self, args ) :
         """

--- a/python/Pubnub.py
+++ b/python/Pubnub.py
@@ -178,7 +178,7 @@ class PubnubBase(object):
         return message
 
 
-    def publish( self, args ) :
+    def publish( self, args, blocking = True ) :
         """
         #**
         #* Publish
@@ -186,6 +186,7 @@ class PubnubBase(object):
         #* Send a message to a channel.
         #*
         #* @param array args with channel and message.
+        #* @param bool blocking If False the call will return directly with no data
         #* @return array success information.
         #**
 
@@ -226,7 +227,7 @@ class PubnubBase(object):
             channel,
             '0',
             message
-        ]}, callback)
+        ]}, callback, blocking)
     
     def presence( self, args ) :
         """
@@ -576,6 +577,21 @@ class PubnubCore(PubnubBase):
         return True
 
 
+def _pubnub_request_instance(request, url, callback=None):
+    try:
+        try: usock = urllib2.urlopen( url, None, 310 )
+        except TypeError: usock = urllib2.urlopen( url, None )
+        response = usock.read()
+        usock.close()
+        resp_json = json.loads(response)
+    except:
+        return None
+
+    if (callback):
+        callback(resp_json)
+    else:
+        return resp_json
+
 
 class Pubnub(PubnubCore):
     def __init__(
@@ -586,7 +602,8 @@ class Pubnub(PubnubCore):
         cipher_key = False,
         ssl_on = False,
         origin = 'pubsub.pubnub.com',
-        pres_uuid = None
+        pres_uuid = None,
+        workers = 10
     ) :
         super(Pubnub, self).__init__(
             publish_key = publish_key,
@@ -597,22 +614,35 @@ class Pubnub(PubnubCore):
             origin = origin,
             uuid = pres_uuid
         )        
+        self._number_of_workers = workers
+        self.pool = None
 
-    def _request( self, request, callback = None ) :
+    def has_pool(self):
+        if self.pool == 'error':
+            return False
+        if self.pool is not None:
+            # Already instanciated
+            return True
+        # Making new pool
+        try:
+            from multiprocessing import Pool
+        except ImportError:
+            self.pool = 'error'
+            return False
+        self.pool = Pool(processes=self._number_of_workers)
+        return True
+
+    def _request( self, request, callback = None, blocking = True ) :
+        # If `blocking` is False it will return immediately without data.
+        # If `blocking` is True it will return the JSON data from the server
+
         ## Build URL
         url = self.getUrl(request)
 
         ## Send Request Expecting JSONP Response
-        try:
-            try: usock = urllib2.urlopen( url, None, 310 )
-            except TypeError: usock = urllib2.urlopen( url, None )
-            response = usock.read()
-            usock.close()
-            resp_json = json.loads(response)
-        except:
-            return None
-            
-        if (callback):
-            callback(resp_json)
+        args = [request, url, callback]
+
+        if blocking is False and self.has_pool():
+            self.pool.apply_async(_pubnub_request_instance, args)
         else:
-            return resp_json
+            return _pubnub_request_instance(*args)

--- a/python/unassembled/Platform.py
+++ b/python/unassembled/Platform.py
@@ -1,3 +1,18 @@
+def _pubnub_request_instance(request, url, callback=None):
+    try:
+        try: usock = urllib2.urlopen( url, None, 310 )
+        except TypeError: usock = urllib2.urlopen( url, None )
+        response = usock.read()
+        usock.close()
+        resp_json = json.loads(response)
+    except:
+        return None
+
+    if (callback):
+        callback(resp_json)
+    else:
+        return resp_json
+
 
 class Pubnub(PubnubCore):
     def __init__(
@@ -8,7 +23,8 @@ class Pubnub(PubnubCore):
         cipher_key = False,
         ssl_on = False,
         origin = 'pubsub.pubnub.com',
-        pres_uuid = None
+        pres_uuid = None,
+        workers = 10
     ) :
         super(Pubnub, self).__init__(
             publish_key = publish_key,
@@ -19,22 +35,35 @@ class Pubnub(PubnubCore):
             origin = origin,
             uuid = pres_uuid
         )        
+        self._number_of_workers = workers
+        self.pool = None
 
-    def _request( self, request, callback = None ) :
+    def has_pool(self):
+        if self.pool == 'error':
+            return False
+        if self.pool is not None:
+            # Already instanciated
+            return True
+        # Making new pool
+        try:
+            from multiprocessing import Pool
+        except ImportError:
+            self.pool = 'error'
+            return False
+        self.pool = Pool(processes=self._number_of_workers)
+        return True
+
+    def _request( self, request, callback = None, blocking = True ) :
+        # If `blocking` is False it will return immediately without data.
+        # If `blocking` is True it will return the JSON data from the server
+
         ## Build URL
         url = self.getUrl(request)
 
         ## Send Request Expecting JSONP Response
-        try:
-            try: usock = urllib2.urlopen( url, None, 310 )
-            except TypeError: usock = urllib2.urlopen( url, None )
-            response = usock.read()
-            usock.close()
-            resp_json = json.loads(response)
-        except:
-            return None
-            
-        if (callback):
-            callback(resp_json)
+        args = [request, url, callback]
+
+        if blocking is False and self.has_pool():
+            self.pool.apply_async(_pubnub_request_instance, args)
         else:
-            return resp_json
+            return _pubnub_request_instance(*args)


### PR DESCRIPTION
I want to use Pubnub on devices with high-latency internet connections. Currently this means my program hangs for 4 seconds every time I call `publish()`. To unfreeze my application I've added an optional background worker pool to `Pubnub` and an extra keywork argument for `publish()`.

Advantages of the implementation:
- Unchanged API. If you keep using `Pubnub.py` as before the behavior will be precisely the same. It won't instantiate the WorkerPool either.
- Easy async requests for everybody using your API
- Entirely optional and configureable per call
