### PR TITLE
Adds parenthesis to all print statements for compatibility with Python3

### DIFF
--- a/Pubnub.py
+++ b/Pubnub.py
@@ -966,7 +966,7 @@ class PubnubBase(object):
             url = url + '?' + "&".join([x + "=" + str(y) for x, y in request[
                 "urlparams"].items() if y is not None and len(str(y)) > 0])
 
-        print url
+        print(url)
         return url
 
     def _channel_registry(self, url=None, params=None, callback=None, error=None):
@@ -1744,7 +1744,7 @@ class PubnubCoreAsync(PubnubBase):
                     self.timeout(1, _connect)
 
             def sub_callback(response):
-                print response
+                print(response)
                 ## ERROR ?
                 if not response or \
                     ('message' in response and
@@ -2064,7 +2064,7 @@ def _requests_request(url, timeout=5):
     except requests.exceptions.Timeout as error:
         msg = str(error)
         return (json.dumps(msg), 0)
-    print resp.text
+    print(resp.text)
     return (resp.text, resp.status_code)
 
 


### PR DESCRIPTION
When using Python 3 I get errors due to print statement lacking parenthesis, like:

```
print url
```

This syntax is compatible with both, python2 and python3, and it is introduced with this PR:

```
print(url)
```

An alternative could be to use logger.debug() to add traces in the code that will be turned off during normal execution.
