### PR TITLE
Workaround a bug in OS X 10.9

### DIFF
--- a/Pubnub.py
+++ b/Pubnub.py
@@ -79,7 +79,21 @@ if sys.platform.startswith("linux"):
     ]
 elif sys.platform.startswith("darwin"):
     # From /usr/include/netinet/tcp.h
-    socket.TCP_KEEPALIVE = 0x10 # idle time used when SO_KEEPALIVE is enabled
+
+    # idle time used when SO_KEEPALIVE is enabled
+    socket.TCP_KEEPALIVE = socket.TCP_KEEPALIVE \
+        if hasattr(socket, 'TCP_KEEPALIVE') \
+        else 0x10
+
+    # interval between keepalives
+    socket.TCP_KEEPINTVL = socket.TCP_KEEPINTVL \
+        if hasattr(socket, 'TCP_KEEPINTVL') \
+        else 0x101
+
+    # number of keepalives before close
+    socket.TCP_KEEPCNT = socket.TCP_KEEPCNT \
+        if hasattr(socket, 'TCP_KEEPCNT') \
+        else 0x102
 
     default_socket_options += [
         # Send first keepalive packet 200 seconds after last data packet


### PR DESCRIPTION
- See: http://www.pubnub.com/community/discussion/554/tcp-keepintvl-error-on-mac-osx-10-9-5-and-python-3-4-x
