### PR TITLE
Bug fix: changed history() http request parameter 'auth_key' to 'auth'

### DIFF
--- a/Pubnub.py
+++ b/Pubnub.py
@@ -906,7 +906,7 @@ class PubnubBase(object):
         params['reverse'] = reverse
         params['start'] = start
         params['end'] = end
-        params['auth_key'] = self.auth_key
+        params['auth'] = self.auth_key
         params['pnsdk'] = self.pnsdk
 
         ## Get History


### PR DESCRIPTION
When history() is used with PAM, we kept receiving HTTP 403 FORBIDDEN error. Upon investigation, we found this little bug.
