### PR TITLE
Update argument defaults in docstrings

### DIFF
--- a/pubnub.py
+++ b/pubnub.py
@@ -420,14 +420,14 @@ class PubnubBase(object):
                         (or included in a comma-separated list, eg. "null,null,abc"), 
                         a new auth_key will be generated and returned for each "null" value.
 
-            read:       (boolean) (default: True)
+            read:       (boolean) (default: False)
                         Read permissions are granted by setting to True.
                         Read permissions are removed by setting to False.
 
-            write:      (boolean) (default: True)
+            write:      (boolean) (default: False)
                         Write permissions are granted by setting to true.
                         Write permissions are removed by setting to false.
-            manage:      (boolean) (default: True)
+            manage:      (boolean) (default: False)
                         Manage permissions are granted by setting to true.
                         Manage permissions are removed by setting to false.
 

--- a/pubnub.py
+++ b/pubnub.py
@@ -456,7 +456,11 @@ class PubnubBase(object):
                 "payload":{
                     "ttl":5,
                     "auths":{
-                        "my_ro_authkey":{"r":1,"w":0}
+                        "my_ro_authkey":{
+                            "m":0,
+                            "r":1,
+                            "w":0
+                        }
                     },
                     "subscribe_key":"my_subkey",
                     "level":"user",
@@ -529,7 +533,11 @@ class PubnubBase(object):
                 "payload":{
                     "ttl":5,
                     "auths":{
-                        "my_authkey":{"r":0,"w":0}
+                        "my_authkey":{
+                            "m":0,
+                            "r":0,
+                            "w":0
+                        }
                     },
                     "subscribe_key":"my_subkey",
                     "level":"user",
@@ -596,9 +604,23 @@ class PubnubBase(object):
                 "payload":{
                     "channels":{
                         "my_channel":{
-                            "auths":{"my_ro_authkey":{"r":1,"w":0},
-                            "my_rw_authkey":{"r":0,"w":1},
-                            "my_admin_authkey":{"r":1,"w":1}
+                            "auths":{
+                                "my_ro_authkey":{
+                                    "m":0,
+                                    "r":1,
+                                    "w":0
+                                },
+                                "my_rw_authkey":{
+                                    "m":0,
+                                    "r":0,
+                                    "w":1
+                                },
+                                "my_admin_authkey":{
+                                    "m":1,
+                                    "r":1,
+                                    "w":1
+                                }
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
Documentation updates.

Changes:
1. The argument defaults specified in the docstring to `Pubnub.grant` did not match the current method signature as of de21caa8524db6bbf7f204aa817b5ddb5d77d3ca. Update the docstring with the correct values.
2. Update sample responses to include the `"m"` ("manage") key that now gets sent from the API.
