### PR TITLE
fix(grant,revoke): Change default ttl to `1440`

### DIFF
--- a/pubnub.py
+++ b/pubnub.py
@@ -383,7 +383,7 @@ class PubnubBase(object):
         return self.auth_key
 
     def grant(self, channel=None, channel_group=None, auth_key=False, read=False,
-              write=False, manage=False, ttl=5, callback=None, error=None):
+              write=False, manage=False, ttl=1440, callback=None, error=None):
         """Method for granting permissions.
 
         This function establishes subscribe and/or write permissions for
@@ -476,7 +476,8 @@ class PubnubBase(object):
             'pnsdk'     : self.pnsdk
         }, callback=callback, error=error)
 
-    def revoke(self, channel=None, channel_group=None, auth_key=None, ttl=1, callback=None, error=None):
+    def revoke(self, channel=None, channel_group=None, auth_key=None, ttl=1440,
+               callback=None, error=None):
         """Method for revoking permissions.
 
         Args:


### PR DESCRIPTION
Update the default time-to-live argument value in `Pubnub.grant` and
`Pubnub.revoke` to 1440.

The docs for PubNub's JavaScript, Ruby, and Python SDKs all describe the
`ttl` parameter's default value as `1440` (or 24 hours):
- [JavaScript](http://www.pubnub.com/docs/web-javascript/api-reference#grant)
- [Ruby](http://www.pubnub.com/docs/ruby/api-reference#grant)
- [Python](http://www.pubnub.com/docs/python/api-reference#grant)

This information was not reflected in the `grant` and `revoke` methods.
Update their defaults to reflect the expected value given the
information from the documentation.
