### PR TITLE
Fix bug for time() api.

### DIFF
--- a/pubnub.py
+++ b/pubnub.py
@@ -1220,7 +1220,7 @@ class PubnubBase(object):
             'time',
             '0'
         ]}, callback)
-        if time is not None:
+        if callback is None and time is not None:
             return time[0]
 
     def _encode(self, request):


### PR DESCRIPTION
The time API provides both a synchronous and asynchronous interface,
however, the function itself does not act appropriately to
accommodate the differences in the underlying APIs.

The bug is in the usage of the object returned from _request:
The caller assumes that the returned time object is a sequence.  For
synchronous calls, this is true, for asynchronous calls, this is false.
For asynchronous calls, a function is returned.

The change modifies the time() function to check for whether the caller
provided a callback before attempting to index the returned time
object.

TESTING:
* Prior to this change, unit-test-full in the python-twisted/tests
  subdirectory failed due to this bug.  After this change, it fails due
  to a different bug, but the time issue is resolved.

* The simple usage:

from pubnub import PubnubTwisted

def time_tw_cb(response):
    print("time tw cb {}".format(response))

pbt = PubnubTwisted(publish_key="key", subscribe_key="subkey"
pbt.time(callback=time_tw_cb)
pbt.start()

  Would fail prior to this change (assuming valid keys), and succeeds
  after.