### PR TITLE
fix callback is not triggered on presence channel groups

### DIFF
--- a/pubnub.py
+++ b/pubnub.py
@@ -2264,11 +2264,7 @@ class PubnubCoreAsync(PubnubBase):
                                 except KeyError:
                                     chobj = self.subscriptions[ch[1]]
 
-                                if ('-pnpres' in channel_list_2[ch[0]]):
-                                    cb = chobj['presence']
-                                else:
-                                    cb = chobj['callback']
-                                _invoke(cb,
+                                _invoke(chobj['callback'],
                                         self.decrypt(response_list[ch[0]]),
                                         chobj['name'].split('-pnpres')[0],
                                         channel_list_2[ch[0]].split


### PR DESCRIPTION
Hi,
We are testing `presence` function on `channel groups` recently and found the callback is not triggered on all "-pnpres" channel event.

After compared result with javascript SDK, we found that [python SDK tries to use `presence` as the callback function ([code link](https://github.com/pubnub/python/blob/master/pubnub.py#L2267-L2268))  and it is not an argument in the `subscribe_group` function.

Therefore, we simply removed the presence channel group check in the SDK and it works as expected now.