### PR TITLE
Changes for GAE Compatibility 

### DIFF
--- a/pubnub/crypto.py
+++ b/pubnub/crypto.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 
-from Cryptodome.Cipher import AES
+from Crypto.Cipher import AES
 
 try:
     from base64 import decodebytes, encodebytes
@@ -14,8 +14,9 @@ try:
     from hashlib import sha256
     digestmod = sha256
 except ImportError:
-    import Cryptodome.Hash.SHA256 as digestmod
+    import Crypto.Hash.SHA256 as digestmod
     sha256 = digestmod.new
+
 
 if sys.version_info > (3, 0):
     v = 3

--- a/pubnub/pnconfiguration.py
+++ b/pubnub/pnconfiguration.py
@@ -23,6 +23,7 @@ class PNConfiguration(object):
         self.enable_subscribe = True
         self.heartbeat_notification_options = PNHeartbeatNotificationOptions.FAILURES
         self.reconnect_policy = PNReconnectionPolicy.NONE
+        self.request_handler = None
 
         self.heartbeat_default_values = True
         self._presence_timeout = PNConfiguration.DEFAULT_PRESENCE_TIMEOUT

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("pubnub")
 class PubNub(PubNubCore):
     """PubNub Python API"""
 
-    def __init__(self, config, request_handler=None):
+    def __init__(self, config, request_handler=None, init_subscribe_handler=False):
         assert isinstance(config, PNConfiguration)
 
         if request_handler is None:
@@ -36,9 +36,8 @@ class PubNub(PubNubCore):
 
         PubNubCore.__init__(self, config)
 
-        # TODO can't subscribe at present on GAE
-        #if self.config.enable_subscribe:
-        #    self._subscription_manager = NativeSubscriptionManager(self)
+        if self.config.enable_subscribe:
+            self._subscription_manager = NativeSubscriptionManager(self)
 
         self._publish_sequence_manager = PublishSequenceManager(PubNubCore.MAX_SEQUENCE)
 

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -36,8 +36,9 @@ class PubNub(PubNubCore):
 
         PubNubCore.__init__(self, config)
 
-        if self.config.enable_subscribe:
-            self._subscription_manager = NativeSubscriptionManager(self)
+        # TODO can't subscribe at present on GAE
+        #if self.config.enable_subscribe:
+        #    self._subscription_manager = NativeSubscriptionManager(self)
 
         self._publish_sequence_manager = PublishSequenceManager(PubNubCore.MAX_SEQUENCE)
 

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -26,10 +26,14 @@ logger = logging.getLogger("pubnub")
 class PubNub(PubNubCore):
     """PubNub Python API"""
 
-    def __init__(self, config):
+    def __init__(self, config, request_handler=None):
         assert isinstance(config, PNConfiguration)
 
-        self._request_handler = RequestsRequestHandler(self)
+        if request_handler is None:
+            self._request_handler = RequestsRequestHandler(self)
+        else:
+            self._request_handler = request_handler
+
         PubNubCore.__init__(self, config)
 
         if self.config.enable_subscribe:

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -26,15 +26,15 @@ logger = logging.getLogger("pubnub")
 class PubNub(PubNubCore):
     """PubNub Python API"""
 
-    def __init__(self, config, request_handler=None, init_subscribe_handler=False):
+    def __init__(self, config):
         assert isinstance(config, PNConfiguration)
 
-        if request_handler is None:
-            self._request_handler = RequestsRequestHandler(self)
-        else:
-            self._request_handler = request_handler(self)
-
         PubNubCore.__init__(self, config)
+
+        if self.config.request_handler:
+            self._request_handler = self.config.request_handler(self)
+        else:
+            self._request_handler = RequestsRequestHandler(self)
 
         if self.config.enable_subscribe:
             self._subscription_manager = NativeSubscriptionManager(self)

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -32,7 +32,7 @@ class PubNub(PubNubCore):
         if request_handler is None:
             self._request_handler = RequestsRequestHandler(self)
         else:
-            self._request_handler = request_handler
+            self._request_handler = request_handler(self)
 
         PubNubCore.__init__(self, config)
 

--- a/pubnub/request_handlers/url_fetch_request_handler.py
+++ b/pubnub/request_handlers/url_fetch_request_handler.py
@@ -4,7 +4,7 @@ import requests
 import six
 
 from requests import Session
-from requests.adapters import HTTPAdapter
+from requests_toolbelt.adapters.appengine import AppEngineAdapter
 
 from pubnub import utils
 from pubnub.enums import PNStatusCategory
@@ -18,17 +18,17 @@ from pubnub.structures import RequestOptions, PlatformOptions, ResponseInfo, Env
 logger = logging.getLogger("pubnub")
 
 
-class RequestsRequestHandler(BaseRequestHandler):
+class URLFetchRequestHandler(BaseRequestHandler):
     """ PubNub Python SDK Native requests handler based on `requests` HTTP library. """
     ENDPOINT_THREAD_COUNTER = 0
 
     def __init__(self, pubnub):
         self.session = Session()
 
-        self.session.mount('http://ps.pndsn.com', HTTPAdapter(max_retries=1, pool_maxsize=500))
-        self.session.mount('https://ps.pndsn.com', HTTPAdapter(max_retries=1, pool_maxsize=500))
-        self.session.mount('http://ps.pndsn.com/v2/subscribe', HTTPAdapter(pool_maxsize=500))
-        self.session.mount('https://ps.pndsn.com/v2/subscribe', HTTPAdapter(pool_maxsize=500))
+        self.session.mount('http://ps.pndsn.com', AppEngineAdapter(max_retries=1, pool_maxsize=500))
+        self.session.mount('https://ps.pndsn.com', AppEngineAdapter(max_retries=1, pool_maxsize=500))
+        self.session.mount('http://ps.pndsn.com/v2/subscribe', AppEngineAdapter(pool_maxsize=500))
+        self.session.mount('https://ps.pndsn.com/v2/subscribe', AppEngineAdapter(pool_maxsize=500))
 
         self.pubnub = pubnub
 
@@ -75,7 +75,7 @@ class RequestsRequestHandler(BaseRequestHandler):
 
         thread = threading.Thread(
             target=client.run,
-            name="EndpointThread-%s-%d" % (endpoint_name, ++RequestsRequestHandler.ENDPOINT_THREAD_COUNTER)
+            name="EndpointThread-%s-%d" % (endpoint_name, ++URLFetchRequestHandler.ENDPOINT_THREAD_COUNTER)
         )
         thread.setDaemon(True)
         thread.start()
@@ -227,8 +227,6 @@ class RequestsRequestHandler(BaseRequestHandler):
             )
 
         return res
-
-
 
 
 class AsyncHTTPClient:

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ),
     install_requires=[
-        'pycryptodomex>=3.3',
+        'pycrypto',
         'requests>=2.4',
+        'requests-toolbelt',
         'six>=1.10'
     ],
     zip_safe=False,


### PR DESCRIPTION
I was looking to use this library on GAE but due to the support of some libraries, I had to make a few changes to this library. I switched Cryptodome for Crypto, and added requests-toolbelt which adds Requests support on GAE. I created a new URLFetchRequestHandler which uses the AppEngineAdapter and added the request handler to the config so I could specify the RequestHandler. You can merge or not merge this update but at the very least I wanted to make it available for other GAE users who wanted to use PubNub now that the Channel API is being deprecated. 