### PR TITLE
Version 4.2.1

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,8 +1,13 @@
 name: python
-version: 4.2.0
+version: 4.2.1
 schema: 1
 scm: github.com/pubnub/python
 changelog:
+  - version: v4.2.1
+    date: Jan 9, 2020
+    changes:
+      - type: bug
+        text: Excluded the tilde symbol from being encoded by the url_encode method to fix invalid PAM signature issue.
   - version: v4.2.0
     date: Dec 24, 2019
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.2.1](https://github.com/pubnub/python/tree/v4.2.1)
+
+  [Full Changelog](https://github.com/pubnub/python/compare/v4.2.0...v4.2.1)
+
+- 🐛Excluded the tilde symbol from being encoded by the url_encode method to fix invalid PAM signature issue.
+
 ## [4.2.0](https://github.com/pubnub/python/tree/v4.2.0)
 
   [Full Changelog](https://github.com/pubnub/python/compare/v4.1.7...v4.2.0)

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -52,7 +52,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "4.2.0"
+    SDK_VERSION = "4.2.1"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/pubnub/utils.py
+++ b/pubnub/utils.py
@@ -44,7 +44,7 @@ def write_value_as_string(data):
 
 
 def url_encode(data):
-    return six.moves.urllib.parse.quote(data, safe="").replace("+", "%2B")
+    return six.moves.urllib.parse.quote(data, safe="~").replace("+", "%2B")
 
 
 def url_write(data):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 codacy-coverage
+pyyaml==5.2
 pycryptodomex
 flake8==3.6.0
 -e git://github.com/pubnub/vcrpy@twisted#egg=vcrpy

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='4.2.0',
+    version='4.2.1',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',


### PR DESCRIPTION
- Excluded the tilde symbol from being encoded by the url_encode method.