### PR TITLE
Handle errors gracefully in incoming messages

### DIFF
--- a/pubnub/workers.py
+++ b/pubnub/workers.py
@@ -99,7 +99,7 @@ class SubscribeMessageWorker(object):
         else:
             try:
                 extracted_message = self._process_message(message.payload)
-            except:
+            except Exception:
                 extracted_message = None
             publisher = message.issuing_client_id
 

--- a/pubnub/workers.py
+++ b/pubnub/workers.py
@@ -97,7 +97,10 @@ class SubscribeMessageWorker(object):
                 )
                 self._listener_manager.announce_membership(membership_result)
         else:
-            extracted_message = self._process_message(message.payload)
+            try:
+                extracted_message = self._process_message(message.payload)
+            except:
+                extracted_message = None
             publisher = message.issuing_client_id
 
             if extracted_message is None:


### PR DESCRIPTION
Currently when Pubnub has cipher_key set and it receives a non-encrypted message, SubscribeMessageWorker thread just dies, and no longer process future messages. I've attached the tracelog below. This patch ensures that if there is any issue with processing incoming messages, it fails gracefully.

```
==Error log==
Exception in thread SubscribeMessageWorker:
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/site-packages/pubnub/workers.py", line 32, in run
    self._take_message()
  File "/usr/local/lib/python3.8/site-packages/pubnub/pubnub.py", line 361, in _take_message
    self._process_incoming_payload(msg)
  File "/usr/local/lib/python3.8/site-packages/pubnub/workers.py", line 100, in _process_incoming_payload
    extracted_message = self._process_message(message.payload)
  File "/usr/local/lib/python3.8/site-packages/pubnub/workers.py", line 42, in _process_message
    return self._pubnub.config.crypto.decrypt(self._pubnub.config.cipher_key, message_input)
  File "/usr/local/lib/python3.8/site-packages/pubnub/crypto.py", line 44, in decrypt
    plain = self.depad((cipher.decrypt(decodebytes(msg.encode('utf-8')))).decode('utf-8'))
AttributeError: 'dict' object has no attribute 'encode'
```