### PR TITLE
fix connection pool to allow any domain name.

### DIFF
--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -29,8 +29,8 @@ class PubNub(PubNubCore):
     def __init__(self, config):
         assert isinstance(config, PNConfiguration)
 
-        self._request_handler = RequestsRequestHandler(self)
         PubNubCore.__init__(self, config)
+        self._request_handler = RequestsRequestHandler(self)
 
         if self.config.enable_subscribe:
             self._subscription_manager = NativeSubscriptionManager(self)

--- a/pubnub/request_handlers/requests_handler.py
+++ b/pubnub/request_handlers/requests_handler.py
@@ -32,10 +32,10 @@ class RequestsRequestHandler(BaseRequestHandler):
     def __init__(self, pubnub):
         self.session = Session()
 
-        self.session.mount('http://ps.pndsn.com', HTTPAdapter(max_retries=1, pool_maxsize=500))
-        self.session.mount('https://ps.pndsn.com', HTTPAdapter(max_retries=1, pool_maxsize=500))
-        self.session.mount('http://ps.pndsn.com/v2/subscribe', HTTPAdapter(pool_maxsize=500))
-        self.session.mount('https://ps.pndsn.com/v2/subscribe', HTTPAdapter(pool_maxsize=500))
+        self.session.mount('http://%s' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
+        self.session.mount('https://%s' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
+        self.session.mount('http://%s/v2/subscribe' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
+        self.session.mount('https://%s/v2/subscribe' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
 
         self.pubnub = pubnub
 

--- a/pubnub/request_handlers/requests_handler.py
+++ b/pubnub/request_handlers/requests_handler.py
@@ -34,8 +34,8 @@ class RequestsRequestHandler(BaseRequestHandler):
 
         self.session.mount('http://%s' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
         self.session.mount('https://%s' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
-        self.session.mount('http://%s/v2/subscribe' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
-        self.session.mount('https://%s/v2/subscribe' % pubnub.config.origin, HTTPAdapter(max_retries=1, pool_maxsize=500))
+        self.session.mount('http://%s/v2/subscribe' % pubnub.config.origin, HTTPAdapter(pool_maxsize=500))
+        self.session.mount('https://%s/v2/subscribe' % pubnub.config.origin, HTTPAdapter(pool_maxsize=500))
 
         self.pubnub = pubnub
 


### PR DESCRIPTION
The Python SDK won't allow persistent sockets for custom domain names.  This PR fixes that.