### PR TITLE
Fix: RuntimeWarning: coroutine 'ClientSession.close' was never awaited

### DIFF
--- a/pubnub/pubnub_asyncio.py
+++ b/pubnub/pubnub_asyncio.py
@@ -39,7 +39,12 @@ class PubNubAsyncio(PubNubCore):
         self._connector = None
         self._session = None
 
-        self.set_connector(aiohttp.TCPConnector(verify_ssl=True))
+        self._connector = aiohttp.TCPConnector(verify_ssl=True)
+        self._session = aiohttp.ClientSession(
+            loop=self.event_loop,
+            conn_timeout=self.config.connect_timeout,
+            connector=self._connector
+        )
 
         if self.config.enable_subscribe:
             self._subscription_manager = AsyncioSubscriptionManager(self)
@@ -49,9 +54,8 @@ class PubNubAsyncio(PubNubCore):
 
         self._telemetry_manager = AsyncioTelemetryManager()
 
-    def set_connector(self, cn):
-        if self._session is not None and self._session.closed:
-            self._session.close()
+    async def set_connector(self, cn):
+        await self._session.close()
 
         self._connector = cn
 
@@ -61,8 +65,8 @@ class PubNubAsyncio(PubNubCore):
             connector=self._connector
         )
 
-    def stop(self):
-        self._session.close()
+    async def stop(self):
+        await self._session.close()
         if self._subscription_manager is not None:
             self._subscription_manager.stop()
 

--- a/scripts/run-tests.py
+++ b/scripts/run-tests.py
@@ -12,7 +12,7 @@ REPO_ROOT = _dname(_dname(os.path.abspath(__file__)))
 os.chdir(os.path.join(REPO_ROOT))
 
 tcmn = 'py.test tests --cov=pubnub --ignore=tests/manual/'
-fcmn = 'flake8 --exclude=scripts/,src/,.cache,.git,.idea,.tox,._trial_temp/'
+fcmn = 'flake8 --exclude=scripts/,src/,.cache,.git,.idea,.tox,._trial_temp/,venv/'
 
 
 def run(command):

--- a/tests/integrational/asyncio/test_channel_groups.py
+++ b/tests/integrational/asyncio/test_channel_groups.py
@@ -51,7 +51,7 @@ async def test_add_remove_single_channel(event_loop, sleeper=asyncio.sleep):
     assert isinstance(env.result, PNChannelGroupsListResult)
     assert len(env.result.channels) == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/groups/add_remove_multiple_channels.yaml')
@@ -93,7 +93,7 @@ async def test_add_remove_multiple_channels(event_loop, sleeper=asyncio.sleep):
     assert isinstance(env.result, PNChannelGroupsListResult)
     assert len(env.result.channels) == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/groups/add_channel_remove_group.yaml')
@@ -132,7 +132,7 @@ async def test_add_channel_remove_group(event_loop, sleeper=asyncio.sleep):
     assert isinstance(env.result, PNChannelGroupsListResult)
     assert len(env.result.channels) == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -165,4 +165,4 @@ async def test_super_call(event_loop):
     env = await pubnub.list_channels_in_channel_group().channel_group(gr).future()
     assert isinstance(env.result, PNChannelGroupsListResult)
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_file_upload.py
+++ b/tests/integrational/asyncio/test_file_upload.py
@@ -48,7 +48,7 @@ async def test_delete_file(event_loop, file_for_upload):
         file_name(envelope.result.name).future()
 
     assert isinstance(delete_envelope.result, PNDeleteFileResult)
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -64,7 +64,7 @@ async def test_list_files(event_loop):
 
     assert isinstance(envelope.result, PNGetFilesResult)
     assert envelope.result.count == 23
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -81,7 +81,7 @@ async def test_send_and_download_file(event_loop, file_for_upload):
         file_name(envelope.result.name).future()
 
     assert isinstance(download_envelope.result, PNDownloadFileResult)
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -101,7 +101,7 @@ async def test_send_and_download_file_encrypted(event_loop, file_for_upload, fil
 
     assert isinstance(download_envelope.result, PNDownloadFileResult)
     assert download_envelope.result.data == bytes(file_upload_test_data["FILE_CONTENT"], "utf-8")
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -118,7 +118,7 @@ async def test_get_file_url(event_loop, file_for_upload):
         file_name(envelope.result.name).future()
 
     assert isinstance(file_url_envelope.result, PNGetFileDownloadURLResult)
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -133,7 +133,7 @@ async def test_fetch_file_upload_s3_data_with_result_invocation(event_loop, file
         file_name(file_upload_test_data["UPLOADED_FILENAME"]).result()
 
     assert isinstance(result, PNFetchFileUploadS3DataResult)
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -153,4 +153,4 @@ async def test_publish_file_message_with_encryption(event_loop, file_upload_test
         ttl(222).future()
 
     assert isinstance(envelope.result, PNPublishFileMessageResult)
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_fire.py
+++ b/tests/integrational/asyncio/test_fire.py
@@ -23,4 +23,4 @@ async def test_single_channel(event_loop):
     assert not envelope.status.is_error()
     assert isinstance(envelope.result, PNFireResult)
     assert isinstance(envelope.status, PNStatus)
-    pn.stop()
+    await pn.stop()

--- a/tests/integrational/asyncio/test_heartbeat.py
+++ b/tests/integrational/asyncio/test_heartbeat.py
@@ -76,4 +76,4 @@ async def test_timeout_event_on_broken_heartbeat(event_loop):
     await callback_presence.wait_for_disconnect()
 
     await pubnub.stop()
-    pubnub_listener.stop()
+    await pubnub_listener.stop()

--- a/tests/integrational/asyncio/test_heartbeat.py
+++ b/tests/integrational/asyncio/test_heartbeat.py
@@ -75,5 +75,5 @@ async def test_timeout_event_on_broken_heartbeat(event_loop):
     pubnub_listener.unsubscribe().channels(ch).execute()
     await callback_presence.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
     pubnub_listener.stop()

--- a/tests/integrational/asyncio/test_here_now.py
+++ b/tests/integrational/asyncio/test_here_now.py
@@ -52,7 +52,7 @@ async def test_single_channel(event_loop, sleeper=asyncio.sleep):
     pubnub.unsubscribe().channels(ch).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/here_now/multiple_channels.yaml')
@@ -102,7 +102,7 @@ async def test_multiple_channels(event_loop, sleeper=asyncio.sleep):
     pubnub.unsubscribe().channels([ch1, ch2]).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/here_now/global.yaml')
@@ -138,7 +138,7 @@ async def test_global(event_loop, sleeper=asyncio.sleep):
     pubnub.unsubscribe().channels([ch1, ch2]).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -158,4 +158,4 @@ async def test_here_now_super_call(event_loop):
     env = await pubnub.here_now().channels(['ch.bar*', 'ch2']).channel_groups("gr.k").future()
     assert isinstance(env.result, PNHereNowResult)
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_history_delete.py
+++ b/tests/integrational/asyncio/test_history_delete.py
@@ -18,7 +18,7 @@ async def test_success(event_loop):
     if res.status.is_error():
         raise AssertionError()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -34,4 +34,4 @@ async def test_delete_with_space_and_wildcard_in_channel_name(event_loop):
     if res.status.is_error():
         raise AssertionError()
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_invocations.py
+++ b/tests/integrational/asyncio/test_invocations.py
@@ -27,7 +27,7 @@ async def test_publish_future(event_loop):
     result = await pubnub.publish().message('hey').channel('blah').result()
     assert isinstance(result, PNPublishResult)
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -44,7 +44,7 @@ async def test_publish_future_raises_pubnub_error(event_loop):
     assert 'Invalid Subscribe Key' in str(exinfo.value)
     assert 400 == exinfo.value._status_code
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -62,7 +62,7 @@ async def test_publish_future_raises_lower_level_error(event_loop):
 
     assert 'Session is closed' in str(exinfo.value)
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -76,7 +76,7 @@ async def test_publish_envelope(event_loop):
     assert isinstance(envelope, AsyncioEnvelope)
     assert not envelope.is_error()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -91,7 +91,7 @@ async def test_publish_envelope_raises(event_loop):
     assert e.is_error()
     assert 400 == e.value()._status_code
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -109,4 +109,4 @@ async def test_publish_envelope_raises_lower_level_error(event_loop):
     assert e.is_error()
     assert str(e.value()) == 'Session is closed'
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_message_count.py
+++ b/tests/integrational/asyncio/test_message_count.py
@@ -13,7 +13,6 @@ def pn(event_loop):
     config.enable_subscribe = False
     pn = PubNubAsyncio(config, custom_event_loop=event_loop)
     yield pn
-    pn.stop()
 
 
 @pn_vcr.use_cassette(
@@ -32,6 +31,8 @@ async def test_single_channel(pn):
     assert envelope.result.channels[chan] == 1
     assert isinstance(envelope.result, PNMessageCountResult)
     assert isinstance(envelope.status, PNStatus)
+
+    await pn.stop()
 
 
 @pn_vcr.use_cassette(
@@ -53,3 +54,5 @@ async def test_multiple_channels(pn):
     assert envelope.result.channels[chan_2] == 0
     assert isinstance(envelope.result, PNMessageCountResult)
     assert isinstance(envelope.status, PNStatus)
+
+    await pn.stop()

--- a/tests/integrational/asyncio/test_pam.py
+++ b/tests/integrational/asyncio/test_pam.py
@@ -35,7 +35,7 @@ async def test_global_level(event_loop):
     assert env.result.manage_enabled is False
     assert env.result.delete_enabled is False
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -56,7 +56,7 @@ async def test_single_channel(event_loop):
     assert env.result.channels[ch].manage_enabled == 0
     assert env.result.channels[ch].delete_enabled == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -78,7 +78,7 @@ async def test_single_channel_with_auth(event_loop):
     assert env.result.channels[ch].auth_keys[auth].manage_enabled == 0
     assert env.result.channels[ch].auth_keys[auth].delete_enabled == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -106,7 +106,7 @@ async def test_multiple_channels(event_loop):
     assert env.result.channels[ch1].delete_enabled is False
     assert env.result.channels[ch2].delete_enabled is False
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -134,7 +134,7 @@ async def test_multiple_channels_with_auth(event_loop):
     assert env.result.channels[ch1].auth_keys[auth].delete_enabled is False
     assert env.result.channels[ch2].auth_keys[auth].delete_enabled is False
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -156,7 +156,7 @@ async def test_single_channel_group(event_loop):
     assert env.result.groups[cg].manage_enabled == 0
     assert env.result.groups[cg].delete_enabled == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -179,7 +179,7 @@ async def test_single_channel_group_with_auth(event_loop):
     assert env.result.groups[gr].auth_keys[auth].manage_enabled == 0
     assert env.result.groups[gr].auth_keys[auth].delete_enabled == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -206,7 +206,7 @@ async def test_multiple_channel_groups(event_loop):
     assert env.result.groups[gr1].delete_enabled is False
     assert env.result.groups[gr2].delete_enabled is False
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -234,4 +234,4 @@ async def test_multiple_channel_groups_with_auth(event_loop):
     assert env.result.groups[gr1].auth_keys[auth].delete_enabled is False
     assert env.result.groups[gr2].auth_keys[auth].delete_enabled is False
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_publish.py
+++ b/tests/integrational/asyncio/test_publish.py
@@ -60,7 +60,7 @@ async def test_publish_mixed_via_get(event_loop):
         asyncio.ensure_future(assert_success_publish_get(pubnub, ["hi", "hi2", "hi3"]))
     )
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -73,7 +73,7 @@ async def test_publish_object_via_get(event_loop):
     pubnub = PubNubAsyncio(pnconf_copy(), custom_event_loop=event_loop)
     await asyncio.ensure_future(assert_success_publish_get(pubnub, {"name": "Alex", "online": True}))
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -88,7 +88,7 @@ async def test_publish_mixed_via_post(event_loop):
         asyncio.ensure_future(assert_success_publish_post(pubnub, True)),
         asyncio.ensure_future(assert_success_publish_post(pubnub, ["hi", "hi2", "hi3"])))
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -100,7 +100,7 @@ async def test_publish_object_via_post(event_loop):
     pubnub = PubNubAsyncio(pnconf_copy(), custom_event_loop=event_loop)
     await asyncio.ensure_future(assert_success_publish_post(pubnub, {"name": "Alex", "online": True}))
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -115,7 +115,7 @@ async def test_publish_mixed_via_get_encrypted(event_loop):
         asyncio.ensure_future(assert_success_publish_get(pubnub, True)),
         asyncio.ensure_future(assert_success_publish_get(pubnub, ["hi", "hi2", "hi3"])))
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -128,7 +128,7 @@ async def test_publish_object_via_get_encrypted(event_loop):
     pubnub = PubNubAsyncio(pnconf_enc_copy(), custom_event_loop=event_loop)
     await asyncio.ensure_future(assert_success_publish_get(pubnub, {"name": "Alex", "online": True}))
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -146,7 +146,7 @@ async def test_publish_mixed_via_post_encrypted(event_loop):
         asyncio.ensure_future(assert_success_publish_post(pubnub, ["hi", "hi2", "hi3"]))
     )
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -159,7 +159,7 @@ async def test_publish_object_via_post_encrypted(event_loop):
     pubnub = PubNubAsyncio(pnconf_enc_copy(), custom_event_loop=event_loop)
     await asyncio.ensure_future(assert_success_publish_post(pubnub, {"name": "Alex", "online": True}))
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -167,7 +167,7 @@ async def test_error_missing_message(event_loop):
     pubnub = PubNubAsyncio(pnconf_copy(), custom_event_loop=event_loop)
     await assert_client_side_error(pubnub.publish().channel(ch).message(None), "Message missing")
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -175,7 +175,7 @@ async def test_error_missing_channel(event_loop):
     pubnub = PubNubAsyncio(pnconf_copy(), custom_event_loop=event_loop)
     await assert_client_side_error(pubnub.publish().channel("").message("hey"), "Channel missing")
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -186,7 +186,7 @@ async def test_error_non_serializable(event_loop):
         pass
 
     await assert_client_side_error(pubnub.publish().channel(ch).message(method), "not JSON serializable")
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -198,7 +198,7 @@ async def test_publish_with_meta(event_loop):
     pubnub = PubNubAsyncio(pnconf_copy(), custom_event_loop=event_loop)
 
     await assert_success_await(pubnub.publish().channel(ch).message("hey").meta({'a': 2, 'b': 'qwer'}))
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -209,7 +209,7 @@ async def test_publish_do_not_store(event_loop):
     pubnub = PubNubAsyncio(pnconf_copy(), custom_event_loop=event_loop)
 
     await assert_success_await(pubnub.publish().channel(ch).message("hey").should_store(False))
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_error_invalid_key(event_loop):
     pubnub = PubNubAsyncio(conf, custom_event_loop=event_loop)
 
     await assert_server_side_error_yield(pubnub.publish().channel(ch).message("hey"), "Invalid Key")
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -246,7 +246,7 @@ async def test_not_permitted(event_loop):
     pubnub = PubNubAsyncio(pnconf, custom_event_loop=event_loop)
 
     await assert_server_side_error_yield(pubnub.publish().channel(ch).message("hey"), "HTTP Client Error (403")
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -258,4 +258,4 @@ async def test_publish_super_admin_call(event_loop):
         'name': 'alex'
     }).future()
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_signal.py
+++ b/tests/integrational/asyncio/test_signal.py
@@ -31,4 +31,4 @@ async def test_single_channel(pnconf, event_loop):
     assert envelope.result.timetoken == '15640051159323676'
     assert isinstance(envelope.result, PNSignalResult)
     assert isinstance(envelope.status, PNStatus)
-    pn.stop()
+    await pn.stop()

--- a/tests/integrational/asyncio/test_ssl.py
+++ b/tests/integrational/asyncio/test_ssl.py
@@ -22,4 +22,4 @@ async def test_publish_string_via_get_encrypted(event_loop):
     res = await pubnub.publish().channel(ch).message("hey").future()
     assert res.result.timetoken > 0
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_state.py
+++ b/tests/integrational/asyncio/test_state.py
@@ -39,7 +39,7 @@ async def test_single_channelx(event_loop):
     assert env.result.channels[ch]['name'] == "Alex"
     assert env.result.channels[ch]['count'] == 5
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/state/single_channel_with_subscription.yaml')
@@ -81,7 +81,7 @@ async def test_single_channel_with_subscription(event_loop, sleeper=asyncio.slee
     pubnub.unsubscribe().channels(ch).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette(
@@ -113,7 +113,7 @@ async def test_multiple_channels(event_loop):
     assert env.result.channels[ch1]['count'] == 5
     assert env.result.channels[ch2]['count'] == 5
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -136,4 +136,4 @@ async def test_state_super_admin_call(event_loop):
         .future()
     assert isinstance(env.result, PNGetStateResult)
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_subscribe.py
+++ b/tests/integrational/asyncio/test_subscribe.py
@@ -43,7 +43,7 @@ async def test_subscribe_unsubscribe(event_loop):
     assert channel not in pubnub.get_subscribed_channels()
     assert len(pubnub.get_subscribed_channels()) == 0
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette('tests/integrational/fixtures/asyncio/subscription/sub_pub_unsub.yaml',
@@ -134,7 +134,7 @@ async def test_encrypted_subscribe_publish_unsubscribe(event_loop):
     pubnub.unsubscribe().channels(channel).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pn_vcr.use_cassette('tests/integrational/fixtures/asyncio/subscription/join_leave.yaml',
@@ -186,7 +186,7 @@ async def test_join_leave(event_loop):
     pubnub_listener.unsubscribe().channels(channel).execute()
     await callback_presence.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
     pubnub_listener.stop()
 
 
@@ -216,7 +216,7 @@ async def test_cg_subscribe_unsubscribe(event_loop, sleeper=asyncio.sleep):
     envelope = await pubnub.remove_channel_from_channel_group().channel_group(gr).channels(ch).future()
     assert envelope.status.original_response['status'] == 200
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/subscription/cg_sub_pub_unsub.yaml')
@@ -260,7 +260,7 @@ async def test_cg_subscribe_publish_unsubscribe(event_loop, sleeper=asyncio.slee
     envelope = await pubnub.remove_channel_from_channel_group().channel_group(gr).channels(ch).future()
     assert envelope.status.original_response['status'] == 200
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/subscription/cg_join_leave.yaml')
@@ -326,7 +326,7 @@ async def test_cg_join_leave(event_loop, sleeper=asyncio.sleep):
     envelope = await pubnub.remove_channel_from_channel_group().channel_group(gr).channels(ch).future()
     assert envelope.status.original_response['status'] == 200
 
-    pubnub.stop()
+    await pubnub.stop()
     pubnub_listener.stop()
 
 
@@ -377,4 +377,4 @@ async def test_unsubscribe_all(event_loop, sleeper=asyncio.sleep):
     envelope = await pubnub.remove_channel_from_channel_group().channel_group(gr2).channels(ch).future()
     assert envelope.status.original_response['status'] == 200
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_subscribe.py
+++ b/tests/integrational/asyncio/test_subscribe.py
@@ -91,8 +91,8 @@ async def test_subscribe_publish_unsubscribe(event_loop):
     pubnub_sub.unsubscribe().channels(channel).execute()
     # await callback.wait_for_disconnect()
 
-    pubnub_pub.stop()
-    pubnub_sub.stop()
+    await pubnub_pub.stop()
+    await pubnub_sub.stop()
 
 
 @pn_vcr.use_cassette('tests/integrational/fixtures/asyncio/subscription/sub_pub_unsub_enc.yaml',
@@ -187,7 +187,7 @@ async def test_join_leave(event_loop):
     await callback_presence.wait_for_disconnect()
 
     await pubnub.stop()
-    pubnub_listener.stop()
+    await pubnub_listener.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/subscription/cg_sub_unsub.yaml')
@@ -327,7 +327,7 @@ async def test_cg_join_leave(event_loop, sleeper=asyncio.sleep):
     assert envelope.status.original_response['status'] == 200
 
     await pubnub.stop()
-    pubnub_listener.stop()
+    await pubnub_listener.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/subscription/unsubscribe_all.yaml')

--- a/tests/integrational/asyncio/test_time.py
+++ b/tests/integrational/asyncio/test_time.py
@@ -18,4 +18,4 @@ async def test_time(event_loop):
     assert int(res) > 0
     assert isinstance(res.date_time(), date)
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/integrational/asyncio/test_unsubscribe_status.py
+++ b/tests/integrational/asyncio/test_unsubscribe_status.py
@@ -63,7 +63,7 @@ def test_access_denied_unsubscribe_operation(event_loop):
     pubnub.subscribe().channels(channel).execute()
     yield from callback.access_denied_event.wait()
 
-    pubnub.stop()
+    yield from pubnub.stop()
 
 #
 # @pytest.mark.asyncio
@@ -78,6 +78,6 @@ def test_access_denied_unsubscribe_operation(event_loop):
 #     pubnub.add_listener(callback)
 #
 #     pubnub.subscribe().channels(channel).execute()
-#     await callback.reconnected_event.wait()
+#     yield from callback.reconnected_event.wait()
 #
-#     pubnub.stop()
+#     yield from pubnub.stop()

--- a/tests/integrational/asyncio/test_unsubscribe_status.py
+++ b/tests/integrational/asyncio/test_unsubscribe_status.py
@@ -78,6 +78,6 @@ def test_access_denied_unsubscribe_operation(event_loop):
 #     pubnub.add_listener(callback)
 #
 #     pubnub.subscribe().channels(channel).execute()
-#     yield from callback.reconnected_event.wait()
+#     await callback.reconnected_event.wait()
 #
-#     yield from pubnub.stop()
+#     await pubnub.stop()

--- a/tests/integrational/asyncio/test_where_now.py
+++ b/tests/integrational/asyncio/test_where_now.py
@@ -39,7 +39,7 @@ async def test_single_channel(event_loop, sleeper=asyncio.sleep):
     pubnub.unsubscribe().channels(ch).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @get_sleeper('tests/integrational/fixtures/asyncio/where_now/multiple_channels.yaml')
@@ -78,7 +78,7 @@ async def test_multiple_channels(event_loop, sleeper=asyncio.sleep):
     pubnub.unsubscribe().channels([ch1, ch2]).execute()
     await callback.wait_for_disconnect()
 
-    pubnub.stop()
+    await pubnub.stop()
 
 
 @pytest.mark.asyncio
@@ -93,4 +93,4 @@ async def test_where_now_super_admin_call(event_loop):
         .result()
     assert isinstance(res, PNWhereNowResult)
 
-    pubnub.stop()
+    await pubnub.stop()

--- a/tests/manual/asyncio/test_reconnections.py
+++ b/tests/manual/asyncio/test_reconnections.py
@@ -40,7 +40,7 @@ async def test_blah():
 
     async def open_again():
         await asyncio.sleep(time_until_open_again)
-        pubnub.set_connector(aiohttp.TCPConnector(conn_timeout=pubnub.config.connect_timeout, verify_ssl=True))
+        await pubnub.set_connector(aiohttp.TCPConnector(conn_timeout=pubnub.config.connect_timeout, verify_ssl=True))
         print(">>> connection is open again")
 
     async def countdown():


### PR DESCRIPTION
Fix for
```
.../venv/lib/python3.9/site-packages/pubnub/pubnub_asyncio.py:70: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
  self._session.close()
```
Which causes unclean errors on loop.closure:
```
ERROR:asyncio:Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x10ee127c0>, 0.69288754)]']
connector: <aiohttp.connector.TCPConnector object at 0x10ee15310>
```