### PR TITLE
Fix: KeyError(6) when PubNubAsyncio configured with PNHeartbeatNotificationOptions.ALL

### DIFF
--- a/pubnub/managers.py
+++ b/pubnub/managers.py
@@ -511,7 +511,7 @@ class TelemetryManager(object):  # pylint: disable=W0612
             PNOperationType.PNDownloadFileAction: 'file',
             PNOperationType.PNSendFileAction: 'file',
 
-            PNOperationType.PNHeartbeatOperation: 'hrt',
+            PNOperationType.PNHeartbeatOperation: 'hb',
 
         }[operation_type]
 

--- a/pubnub/managers.py
+++ b/pubnub/managers.py
@@ -511,6 +511,8 @@ class TelemetryManager(object):  # pylint: disable=W0612
             PNOperationType.PNDownloadFileAction: 'file',
             PNOperationType.PNSendFileAction: 'file',
 
+            PNOperationType.PNHeartbeatOperation: 'hrt',
+
         }[operation_type]
 
         return endpoint


### PR DESCRIPTION
If using PubNubAsyncio and heartbeat notifications is set to PNHeartbeatNotificationOptions.ALL, a KeyError(6) is generated for status callbacks due to a failed lookup for the int value 6 (PNOperationType.PNHeartbeatOperation) in the managers static method "endpoint_name_for_operation".