### PR TITLE
Fix for is_error

### DIFF
--- a/pubnub/models/consumer/common.py
+++ b/pubnub/models/consumer/common.py
@@ -20,4 +20,4 @@ class PNStatus:
         self.affected_groups = None
 
     def is_error(self):
-        return self.error is not None
+        return True if self.error else False

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -216,7 +216,7 @@ class NativeSubscriptionManager(SubscriptionManager):
 
         def heartbeat_callback(raw_result, status):
             heartbeat_verbosity = self._pubnub.config.heartbeat_notification_options
-            if status.is_error:
+            if status.is_error():
                 if heartbeat_verbosity in (PNHeartbeatNotificationOptions.ALL, PNHeartbeatNotificationOptions.FAILURES):
                     self._listener_manager.announce_status(status)
             else:

--- a/pubnub/pubnub_asyncio.py
+++ b/pubnub/pubnub_asyncio.py
@@ -503,7 +503,7 @@ class AsyncioSubscriptionManager(SubscriptionManager):
             envelope = await heartbeat_call
 
             heartbeat_verbosity = self._pubnub.config.heartbeat_notification_options
-            if envelope.status.is_error:
+            if envelope.status.is_error():
                 if heartbeat_verbosity in (PNHeartbeatNotificationOptions.ALL, PNHeartbeatNotificationOptions.FAILURES):
                     self._listener_manager.announce_status(envelope.status)
             else:


### PR DESCRIPTION
This fixes the check for is_error when it is set to False instead of None.
There were also 2 places where ".is_error" was called instead of ".is_error()"