### PR TITLE
fix: Remove unwanted output while calling `fetch_messages`

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: python
-version: 6.0.0
+version: 6.0.1
 schema: 1
 scm: github.com/pubnub/python
 sdks:
@@ -18,7 +18,7 @@ sdks:
         distributions:
           - distribution-type: library
             distribution-repository: package
-            package-name: pubnub-6.0.0
+            package-name: pubnub-6.0.1
             location: https://pypi.org/project/pubnub/
             supported-platforms:
               supported-operating-systems:
@@ -97,8 +97,8 @@ sdks:
           -
             distribution-type: library
             distribution-repository: git release
-            package-name: pubnub-6.0.0
-            location: https://github.com/pubnub/python/releases/download/v6.0.0/pubnub-6.0.0.tar.gz
+            package-name: pubnub-6.0.1
+            location: https://github.com/pubnub/python/releases/download/v6.0.1/pubnub-6.0.1.tar.gz
             supported-platforms:
               supported-operating-systems:
                 Linux:
@@ -169,6 +169,11 @@ sdks:
                 license-url: https://github.com/aio-libs/aiohttp/blob/master/LICENSE.txt
                 is-required: Required
 changelog:
+  - date: 2022-02-01
+    version: v6.0.1
+    changes:
+      - type: bug
+        text: "Remove unwanted output while calling `fetch_messages`."
   - date: 2022-01-13
     version: v6.0.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v6.0.1
+February 01 2022
+
+#### Fixed
+- Remove unwanted output while calling `fetch_messages`.
+
 ## v6.0.0
 January 13 2022
 

--- a/pubnub/models/consumer/history.py
+++ b/pubnub/models/consumer/history.py
@@ -65,7 +65,6 @@ class PNFetchMessagesResult(object):
     @classmethod
     def from_json(cls, json_input, include_message_actions=False, start_timetoken=None, end_timetoken=None):
         channels = {}
-        print(json_input['channels'])
 
         for key, entry in json_input['channels'].items():
             channels[key] = []

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -65,7 +65,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "6.0.0"
+    SDK_VERSION = "6.0.1"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='6.0.0',
+    version='6.0.1',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',


### PR DESCRIPTION
fix: Remove unwanted output while calling `fetch_messages`