### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ setup(
     author='PubNub',
     author_email='support@pubnub.com',
     url='http://pubnub.com',
+    project_urls={
+        'Source': 'https://github.com/pubnub/python',
+    },
     packages=find_packages(exclude=("examples*", 'tests*')),
     license='MIT',
     classifiers=(


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)