### PR TITLE
Fix error in encryption

### DIFF
--- a/pubnub/endpoints/endpoint.py
+++ b/pubnub/endpoints/endpoint.py
@@ -24,6 +24,7 @@ class Endpoint(object):
     SERVER_RESPONSE_BAD_REQUEST = 400
 
     __metaclass__ = ABCMeta
+    _path = None
 
     def __init__(self, pubnub):
         self.pubnub = pubnub
@@ -110,12 +111,17 @@ class Endpoint(object):
     def encoded_params(self):
         return {}
 
+    def get_path(self):
+        if not self._path:
+            self._path = self.build_path()
+        return self._path
+
     def options(self):
         data = self.build_data()
         if data and self.__compress_request():
             data = zlib.compress(data.encode('utf-8'), level=2)
         return RequestOptions(
-            path=self.build_path(),
+            path=self.get_path(),
             params_callback=self.build_params_callback(),
             method=self.http_method(),
             request_timeout=self.request_timeout(),

--- a/pubnub/utils.py
+++ b/pubnub/utils.py
@@ -166,7 +166,7 @@ def datetime_now():
 def sign_request(endpoint, pn, custom_params, method, body):
     custom_params['timestamp'] = str(pn.timestamp())
 
-    request_url = endpoint.build_path()
+    request_url = endpoint.get_path()
 
     encoded_query_string = prepare_pam_arguments(custom_params)
 


### PR DESCRIPTION
fix: Fix error in encryption using random initialization vector

Error was caused when using random initialization vector. Request path was encrypted two times, once to prepare signage and second one when sending the request