### PR TITLE
Fix flaky test native_threads/test_where_now

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: python
-version: 6.5.1
+version: 7.0.0
 schema: 1
 scm: github.com/pubnub/python
 sdks:
@@ -18,7 +18,7 @@ sdks:
         distributions:
           - distribution-type: library
             distribution-repository: package
-            package-name: pubnub-6.5.1
+            package-name: pubnub-7.0.0
             location: https://pypi.org/project/pubnub/
             supported-platforms:
               supported-operating-systems:
@@ -97,8 +97,8 @@ sdks:
           -
             distribution-type: library
             distribution-repository: git release
-            package-name: pubnub-6.5.1
-            location: https://github.com/pubnub/python/releases/download/v6.5.1/pubnub-6.5.1.tar.gz
+            package-name: pubnub-7.0.0
+            location: https://github.com/pubnub/python/releases/download/7.0.0/pubnub-7.0.0.tar.gz
             supported-platforms:
               supported-operating-systems:
                 Linux:
@@ -169,6 +169,13 @@ sdks:
                 license-url: https://github.com/aio-libs/aiohttp/blob/master/LICENSE.txt
                 is-required: Required
 changelog:
+  - date: 2022-08-23
+    version: 7.0.0
+    changes:
+      - type: improvement
+        text: "Update build process to include python v3.10-dev and remove v3.6."
+      - type: improvement
+        text: "Fix of randomly failing tests of `where_now feature`."
   - date: 2022-08-02
     version: v6.5.1
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -24,10 +24,10 @@ sdks:
               supported-operating-systems:
                 Linux:
                   runtime-version:
-                    - Python 3.6
                     - Python 3.7
                     - Python 3.8
                     - Python 3.9
+                    - Python 3.10
                   minimum-os-version:
                     - Ubuntu 12.04
                   maximum-os-version:
@@ -35,31 +35,31 @@ sdks:
                   target-architecture:
                     - x86
                     - x86-64
-                  macOS:
-                    runtime-version:
-                      - Python 3.6
-                      - Python 3.7
-                      - Python 3.8
-                      - Python 3.9
-                    minimum-os-version:
-                      - macOS 10.12
-                    maximum-os-version:
-                      - macOS 11.0.1
-                    target-architecture:
-                      - x86-64
-                  Windows:
-                    runtime-version:
-                      - Python 3.6
-                      - Python 3.7
-                      - Python 3.8
-                      - Python 3.9
-                    minimum-os-version:
-                      - Windows Vista Ultimate
-                    maximum-os-version:
-                      - Windows 10 Home
-                    target-architecture:
-                      - x86
-                      - x86-64
+                macOS:
+                  runtime-version:
+                    - Python 3.7
+                    - Python 3.8
+                    - Python 3.9
+                    - Python 3.10
+                  minimum-os-version:
+                    - macOS 10.12
+                  maximum-os-version:
+                    - macOS 11.0.1
+                  target-architecture:
+                    - x86-64
+                Windows:
+                  runtime-version:
+                    - Python 3.7
+                    - Python 3.8
+                    - Python 3.9
+                    - Python 3.10
+                  minimum-os-version:
+                    - Windows Vista Ultimate
+                  maximum-os-version:
+                    - Windows 10 Home
+                  target-architecture:
+                    - x86
+                    - x86-64
             requires:
               - name: requests
                 min-version: "2.4"
@@ -103,10 +103,10 @@ sdks:
               supported-operating-systems:
                 Linux:
                   runtime-version:
-                    - Python 3.6
                     - Python 3.7
                     - Python 3.8
                     - Python 3.9
+                    - Python 3.10
                   minimum-os-version:
                     - Ubuntu 12.04
                   maximum-os-version:
@@ -114,31 +114,31 @@ sdks:
                   target-architecture:
                     - x86
                     - x86-64
-                  macOS:
-                    runtime-version:
-                      - Python 3.6
-                      - Python 3.7
-                      - Python 3.8
-                      - Python 3.9
-                    minimum-os-version:
-                      - macOS 10.12
-                    maximum-os-version:
-                      - macOS 11.0.1
-                    target-architecture:
-                      - x86-64
-                  Windows:
-                    runtime-version:
-                      - Python 3.6
-                      - Python 3.7
-                      - Python 3.8
-                      - Python 3.9
-                    minimum-os-version:
-                      - Windows Vista Ultimate
-                    maximum-os-version:
-                      - Windows 10 Home
-                    target-architecture:
-                      - x86
-                      - x86-64
+                macOS:
+                  runtime-version:
+                    - Python 3.7
+                    - Python 3.8
+                    - Python 3.9
+                    - Python 3.10
+                  minimum-os-version:
+                    - macOS 10.12
+                  maximum-os-version:
+                    - macOS 11.0.1
+                  target-architecture:
+                    - x86-64
+                Windows:
+                  runtime-version:
+                    - Python 3.7
+                    - Python 3.8
+                    - Python 3.9
+                    - Python 3.10
+                  minimum-os-version:
+                    - Windows Vista Ultimate
+                  maximum-os-version:
+                    - Windows 10 Home
+                  target-architecture:
+                    - x86
+                    - x86-64
             requires:
               -
                 name: requests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ stages:
 jobs:
   include:
     - stage: "test"
-      name: 'Python 3.6'
-      python: '3.6.12'
-      script: python scripts/run-tests.py
-    - name: 'Python 3.7'
-      python: '3.7.9'
+      name: 'Python 3.7'
+      python: '3.7.13'
       script: python scripts/run-tests.py
     - name: 'Python 3.8'
-      python: '3.8.6'
+      python: '3.8.13'
       script: python scripts/run-tests.py
     - name: 'Python 3.9'
-      python: '3.9.1'
+      python: '3.9.13'
+      script: python scripts/run-tests.py
+    - name: 'Python 3.10'
+      python: '3.10-dev'
       script: python scripts/run-tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.0.0
+August 23 2022
+
+#### Modified
+- Update build process to include python v3.10-dev and remove v3.6.
+- Fix of randomly failing tests of `where_now feature`.
+
 ## v6.5.1
 August 02 2022
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,22 +1,22 @@
 # Developers manual
 
 ## Supported Python versions
-We support Python 3.6, 3.7, 3.8, 3.9
+We support Python 3.7, 3.8, 3.9, 3.10
 
 ## Supported platforms
 We maintain and test our SDK using Travis.CI and Ubuntu.
-Windows/MacOS/BSD platforms support was verified only once, after SDK v4.0 release. We did not test the newer releases with these platforms. 
+Windows/MacOS/BSD platforms support was verified only once, after SDK v4.0 release. We did not test the newer releases with these platforms.
 
 ## Event Loop Frameworks
 ### Native (`threading`)
 Native implementation concerns using `requests` library (https://github.com/requests/requests), a wrapper for a lower level urllib3 (https://github.com/shazow/urllib3).
 urllib2 is not supported, there is an outline of request handler for it (which doesn't work, just the outline) can be found at (https://github.com/pubnub/python/blob/master/pubnub/request_handlers/urllib2_handler.py).
-All listed Python versions are supported. 
+All listed Python versions are supported.
 
 #### sync
 Synchronous calls can be invoked by using `sync()` call. This will return Envelope object https://github.com/pubnub/python/blob/037a6829c341471c2c78a7a429f02dec671fd791/pubnub/structures.py#L79-L82 which wraps both Result and Status. All exceptions are triggered natively using `raise Exception` syntax. The idea was to use 2 types of final execution methods like in Asyncio/Tornado. These fixes are postponed until next major release (v5.0.0):
 - `result()` should return just Response and natively raise an exception if there is one
-- `sync()` should return Envelope(as is now), but do not raise any exceptions 
+- `sync()` should return Envelope(as is now), but do not raise any exceptions
 The work on it has been started in branch 'fix-errors-handling', but as were mentioned above, was postponed.
 
 #### async

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -83,7 +83,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "6.5.1"
+    SDK_VERSION = "7.0.0"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ aiohttp
 requests
 cbor2
 behave
--e git+https://github.com/pubnub/vcrpy.git@aiotthp_redirect_enabled#egg=vcrpy
+vcrpy

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='6.5.1',
+    version='7.0.0',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',

--- a/tests/integrational/fixtures/native_threads/where_now/multiple_channels.yaml
+++ b/tests/integrational/fixtures/native_threads/where_now/multiple_channels.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PubNub-Python/6.5.1
+    method: GET
+    uri: https://ps.pndsn.com/v2/subscribe/sub-c-mock-key/state-native-sync-ch-1,state-native-sync-ch-2/0?uuid=state-native-sync-uuid
+  response:
+    body:
+      string: '{"t":{"t":"16608278698485679","r":43},"m":[]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - text/javascript; charset="UTF-8"
+      Date:
+      - Thu, 18 Aug 2022 13:04:29 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PubNub-Python/6.5.1
+    method: GET
+    uri: https://ps.pndsn.com/v2/presence/sub-key/sub-c-mock-key/uuid/state-native-sync-uuid?uuid=state-native-sync-uuid
+  response:
+    body:
+      string: '{"status": 200, "message": "OK", "payload": {"channels": ["state-native-sync-ch-2",
+        "state-native-sync-ch-1"]}, "service": "Presence"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - text/javascript; charset="UTF-8"
+      Date:
+      - Thu, 18 Aug 2022 13:04:40 GMT
+      Server:
+      - Pubnub Presence
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PubNub-Python/6.5.1
+    method: GET
+    uri: https://ps.pndsn.com/v2/presence/sub-key/sub-c-mock-key/channel/state-native-sync-ch-1,state-native-sync-ch-2/leave?uuid=state-native-sync-uuid
+  response:
+    body:
+      string: '{"status": 200, "message": "OK", "action": "leave", "service": "Presence"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - text/javascript; charset="UTF-8"
+      Date:
+      - Thu, 18 Aug 2022 13:04:40 GMT
+      Server:
+      - Pubnub Presence
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrational/fixtures/native_threads/where_now/single_channel.yaml
+++ b/tests/integrational/fixtures/native_threads/where_now/single_channel.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PubNub-Python/6.5.1
+    method: GET
+    uri: https://ps.pndsn.com/v2/subscribe/sub-c-mock-key/wherenow-asyncio-channel/0?uuid=wherenow-asyncio-uuid
+  response:
+    body:
+      string: '{"t":{"t":"16608276639105030","r":43},"m":[]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - text/javascript; charset="UTF-8"
+      Date:
+      - Thu, 18 Aug 2022 13:01:04 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PubNub-Python/6.5.1
+    method: GET
+    uri: https://ps.pndsn.com/v2/presence/sub-key/sub-c-mock-key/uuid/wherenow-asyncio-uuid?uuid=wherenow-asyncio-uuid
+  response:
+    body:
+      string: '{"status": 200, "message": "OK", "payload": {"channels": ["wherenow-asyncio-channel"]},
+        "service": "Presence"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/javascript; charset="UTF-8"
+      Date:
+      - Thu, 18 Aug 2022 13:01:14 GMT
+      Server:
+      - Pubnub Presence
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - PubNub-Python/6.5.1
+    method: GET
+    uri: https://ps.pndsn.com/v2/presence/sub-key/sub-c-mock-key/channel/wherenow-asyncio-channel/leave?uuid=wherenow-asyncio-uuid
+  response:
+    body:
+      string: '{"status": 200, "message": "OK", "action": "leave", "service": "Presence"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '74'
+      Content-Type:
+      - text/javascript; charset="UTF-8"
+      Date:
+      - Thu, 18 Aug 2022 13:01:14 GMT
+      Server:
+      - Pubnub Presence
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
build: Update build process to include python v3.10-dev and remove v3.6
test: Fix of randomly failing tests of `where_now feature`