### PR TITLE
Fix `User.update()` method

### DIFF
--- a/pubnub/models/consumer/v3/user.py
+++ b/pubnub/models/consumer/v3/user.py
@@ -41,7 +41,7 @@ class User(PNResource):
         return self
 
     def update(self):
-        self._get = True
+        self._update = True
         return self
 
     def join(self):


### PR DESCRIPTION
I assume it should be this way because inherited `PNResource.is_update()` method checks `_update` field.

Setting `_update = True` manually allowed me to solve 403 issue with my app.