### PR TITLE
Add support for switching cipher methods

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: python
-version: 7.1.0
+version: 7.2.0
 schema: 1
 scm: github.com/pubnub/python
 sdks:
@@ -18,7 +18,7 @@ sdks:
         distributions:
           - distribution-type: library
             distribution-repository: package
-            package-name: pubnub-7.1.0
+            package-name: pubnub-7.2.0
             location: https://pypi.org/project/pubnub/
             supported-platforms:
               supported-operating-systems:
@@ -97,8 +97,8 @@ sdks:
           -
             distribution-type: library
             distribution-repository: git release
-            package-name: pubnub-7.1.0
-            location: https://github.com/pubnub/python/releases/download/7.1.0/pubnub-7.1.0.tar.gz
+            package-name: pubnub-7.2.0
+            location: https://github.com/pubnub/python/releases/download/7.2.0/pubnub-7.2.0.tar.gz
             supported-platforms:
               supported-operating-systems:
                 Linux:
@@ -169,6 +169,11 @@ sdks:
                 license-url: https://github.com/aio-libs/aiohttp/blob/master/LICENSE.txt
                 is-required: Required
 changelog:
+  - date: 2023-07-06
+    version: 7.2.0
+    changes:
+      - type: feature
+        text: "Introduced option to select ciphering method for encoding messages and files. The default behavior is unchanged. More can be read [in this comment](https://github.com/pubnub/python/pull/156#issuecomment-1623307799)."
   - date: 2023-01-17
     version: 7.1.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.2.0
+July 06 2023
+
+#### Added
+- Introduced option to select ciphering method for encoding messages and files. The default behavior is unchanged. More can be read [in this comment](https://github.com/pubnub/python/pull/156#issuecomment-1623307799).
+
 ## 7.1.0
 January 17 2023
 

--- a/examples/crypto.py
+++ b/examples/crypto.py
@@ -1,0 +1,47 @@
+from Cryptodome.Cipher import AES
+from os import getenv
+from pubnub.pnconfiguration import PNConfiguration
+from pubnub.pubnub import PubNub
+from time import sleep
+
+channel = 'cipher_algorithm_experiment'
+
+
+def PNFactory(cipher_mode=AES.MODE_GCM, fallback_cipher_mode=AES.MODE_CBC) -> PubNub:
+    config = config = PNConfiguration()
+    config.publish_key = getenv('PN_KEY_PUBLISH')
+    config.subscribe_key = getenv('PN_KEY_SUBSCRIBE')
+    config.secret_key = getenv('PN_KEY_SECRET')
+    config.cipher_key = getenv('PN_KEY_CIPHER')
+    config.user_id = 'experiment'
+    config.cipher_mode = cipher_mode
+    config.fallback_cipher_mode = fallback_cipher_mode
+
+    return PubNub(config)
+
+
+# let's build history with legacy AES.CBC
+pn = PNFactory(cipher_mode=AES.MODE_CBC, fallback_cipher_mode=None)
+pn.publish().channel(channel).message('message encrypted with CBC').sync()
+pn.publish().channel(channel).message('message encrypted with CBC').sync()
+
+# now with upgraded config
+pn = PNFactory(cipher_mode=AES.MODE_GCM, fallback_cipher_mode=AES.MODE_CBC)
+pn.publish().channel(channel).message('message encrypted with GCM').sync()
+pn.publish().channel(channel).message('message encrypted with GCM').sync()
+
+# give some time to store messages
+sleep(3)
+
+# after upgrade decoding with GCM and fallback CBC
+pn = PNFactory(cipher_mode=AES.MODE_GCM, fallback_cipher_mode=AES.MODE_CBC)
+messages = pn.history().channel(channel).sync()
+print([message.entry for message in messages.result.messages])
+
+# before upgrade decoding with CBC and without fallback
+pn = PNFactory(cipher_mode=AES.MODE_CBC, fallback_cipher_mode=None)
+try:
+    messages = pn.history().channel(channel).sync()
+    print([message.entry for message in messages.result.messages])
+except UnicodeDecodeError:
+    print('Unable to decode - Exception has been thrown')

--- a/pubnub/crypto.py
+++ b/pubnub/crypto.py
@@ -95,6 +95,11 @@ class PubNubFileCrypto(PubNubCryptodome):
     def decrypt(self, key, file):
         secret = self.get_secret(key)
         initialization_vector, extracted_file = self.extract_random_iv(file, use_random_iv=True)
-        cipher = AES.new(bytes(secret[0:32], "utf-8"), self.mode, initialization_vector)
+        try:
+            cipher = AES.new(bytes(secret[0:32], "utf-8"), self.mode, initialization_vector)
+            result = unpad(cipher.decrypt(extracted_file), 16)
+        except ValueError:
+            cipher = AES.new(bytes(secret[0:32], "utf-8"), self.fallback_mode, initialization_vector)
+            result = unpad(cipher.decrypt(extracted_file), 16)
 
-        return unpad(cipher.decrypt(extracted_file), 16)
+        return result

--- a/pubnub/crypto.py
+++ b/pubnub/crypto.py
@@ -3,7 +3,7 @@ import json
 import random
 from base64 import decodebytes, encodebytes
 
-from .crypto_core import PubNubCrypto
+from pubnub.crypto_core import PubNubCrypto
 from Cryptodome.Cipher import AES
 from Cryptodome.Util.Padding import pad, unpad
 

--- a/pubnub/crypto.py
+++ b/pubnub/crypto.py
@@ -12,14 +12,19 @@ Initial16bytes = '0123456789012345'
 
 
 class PubNubCryptodome(PubNubCrypto):
+    mode = AES.MODE_CBC
+    fallback_mode = None
+
     def __init__(self, pubnub_config):
         self.pubnub_configuration = pubnub_config
+        self.mode = pubnub_config.cipher_mode
+        self.fallback_mode = pubnub_config.fallback_cipher_mode
 
     def encrypt(self, key, msg, use_random_iv=False):
         secret = self.get_secret(key)
         initialization_vector = self.get_initialization_vector(use_random_iv)
 
-        cipher = AES.new(bytes(secret[0:32], 'utf-8'), AES.MODE_CBC, bytes(initialization_vector, 'utf-8'))
+        cipher = AES.new(bytes(secret[0:32], 'utf-8'), self.mode, bytes(initialization_vector, 'utf-8'))
         encrypted_message = cipher.encrypt(self.pad(msg.encode('utf-8')))
         msg_with_iv = self.append_random_iv(encrypted_message, use_random_iv, bytes(initialization_vector, "utf-8"))
 
@@ -30,8 +35,15 @@ class PubNubCryptodome(PubNubCrypto):
 
         decoded_message = decodebytes(msg.encode("utf-8"))
         initialization_vector, extracted_message = self.extract_random_iv(decoded_message, use_random_iv)
-        cipher = AES.new(bytes(secret[0:32], "utf-8"), AES.MODE_CBC, initialization_vector)
-        plain = self.depad((cipher.decrypt(extracted_message)).decode('utf-8'))
+        cipher = AES.new(bytes(secret[0:32], "utf-8"), self.mode, initialization_vector)
+        try:
+            plain = self.depad((cipher.decrypt(extracted_message)).decode('utf-8'))
+        except UnicodeDecodeError as e:
+            if not self.fallback_mode:
+                raise e
+
+            cipher = AES.new(bytes(secret[0:32], "utf-8"), self.fallback_mode, initialization_vector)
+            plain = self.depad((cipher.decrypt(extracted_message)).decode('utf-8'))
 
         try:
             return json.loads(plain)
@@ -71,7 +83,7 @@ class PubNubFileCrypto(PubNubCryptodome):
     def encrypt(self, key, file):
         secret = self.get_secret(key)
         initialization_vector = self.get_initialization_vector(use_random_iv=True)
-        cipher = AES.new(bytes(secret[0:32], "utf-8"), AES.MODE_CBC, bytes(initialization_vector, 'utf-8'))
+        cipher = AES.new(bytes(secret[0:32], "utf-8"), self.mode, bytes(initialization_vector, 'utf-8'))
         initialization_vector = bytes(initialization_vector, 'utf-8')
 
         return self.append_random_iv(
@@ -83,6 +95,6 @@ class PubNubFileCrypto(PubNubCryptodome):
     def decrypt(self, key, file):
         secret = self.get_secret(key)
         initialization_vector, extracted_file = self.extract_random_iv(file, use_random_iv=True)
-        cipher = AES.new(bytes(secret[0:32], "utf-8"), AES.MODE_CBC, initialization_vector)
+        cipher = AES.new(bytes(secret[0:32], "utf-8"), self.mode, initialization_vector)
 
         return unpad(cipher.decrypt(extracted_file), 16)

--- a/pubnub/pnconfiguration.py
+++ b/pubnub/pnconfiguration.py
@@ -1,10 +1,12 @@
-from .enums import PNHeartbeatNotificationOptions, PNReconnectionPolicy
 from Cryptodome.Cipher import AES
+from pubnub.enums import PNHeartbeatNotificationOptions, PNReconnectionPolicy
+from pubnub.exceptions import PubNubException
 
 
 class PNConfiguration(object):
     DEFAULT_PRESENCE_TIMEOUT = 300
     DEFAULT_HEARTBEAT_INTERVAL = 280
+    ALLOWED_AES_MODES = [AES.MODE_CBC, AES.MODE_GCM]
 
     def __init__(self):
         # TODO: add validation
@@ -70,6 +72,8 @@ class PNConfiguration(object):
 
     @cipher_mode.setter
     def cipher_mode(self, cipher_mode):
+        if cipher_mode not in self.ALLOWED_AES_MODES:
+            raise PubNubException('Cipher mode not supported')
         if cipher_mode is not self._cipher_mode:
             self._cipher_mode = cipher_mode
             self.crypto_instance = None
@@ -80,6 +84,8 @@ class PNConfiguration(object):
 
     @fallback_cipher_mode.setter
     def fallback_cipher_mode(self, fallback_cipher_mode):
+        if fallback_cipher_mode not in self.ALLOWED_AES_MODES:
+            raise PubNubException('Cipher mode not supported')
         if fallback_cipher_mode is not self._fallback_cipher_mode:
             self._fallback_cipher_mode = fallback_cipher_mode
             self.crypto_instance = None

--- a/pubnub/pnconfiguration.py
+++ b/pubnub/pnconfiguration.py
@@ -20,8 +20,8 @@ class PNConfiguration(object):
         self.publish_key = None
         self.secret_key = None
         self.cipher_key = None
-        self._cipher_mode = AES.MODE_GCM
-        self._fallback_cipher_mode = AES.MODE_CBC
+        self._cipher_mode = AES.MODE_CBC
+        self._fallback_cipher_mode = None
         self.auth_key = None
         self.filter_expression = None
         self.enable_subscribe = True

--- a/pubnub/pnconfiguration.py
+++ b/pubnub/pnconfiguration.py
@@ -1,4 +1,5 @@
 from .enums import PNHeartbeatNotificationOptions, PNReconnectionPolicy
+from Cryptodome.Cipher import AES
 
 
 class PNConfiguration(object):
@@ -17,6 +18,8 @@ class PNConfiguration(object):
         self.publish_key = None
         self.secret_key = None
         self.cipher_key = None
+        self._cipher_mode = AES.MODE_GCM
+        self._fallback_cipher_mode = AES.MODE_CBC
         self.auth_key = None
         self.filter_expression = None
         self.enable_subscribe = True
@@ -60,6 +63,26 @@ class PNConfiguration(object):
 
     def set_presence_timeout(self, timeout):
         self.set_presence_timeout_with_custom_interval(timeout, (timeout / 2) - 1)
+
+    @property
+    def cipher_mode(self):
+        return self._cipher_mode
+
+    @cipher_mode.setter
+    def cipher_mode(self, cipher_mode):
+        if cipher_mode is not self._cipher_mode:
+            self._cipher_mode = cipher_mode
+            self.crypto_instance = None
+
+    @property
+    def fallback_cipher_mode(self):
+        return self._fallback_cipher_mode
+
+    @fallback_cipher_mode.setter
+    def fallback_cipher_mode(self, fallback_cipher_mode):
+        if fallback_cipher_mode is not self._fallback_cipher_mode:
+            self._fallback_cipher_mode = fallback_cipher_mode
+            self.crypto_instance = None
 
     @property
     def crypto(self):

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -83,7 +83,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "7.1.0"
+    SDK_VERSION = "7.2.0"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='7.1.0',
+    version='7.2.0',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',

--- a/tests/integrational/fixtures/native_sync/file_upload/send_and_download_encrypted_file_fallback_decode.json
+++ b/tests/integrational/fixtures/native_sync/file_upload/send_and_download_encrypted_file_fallback_decode.json
@@ -1,0 +1,299 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://ps.pndsn.com/v1/files/{PN_KEY_SUBSCRIBE}/channels/files_native_sync_ch/generate-upload-url?uuid=uuid-mock",
+                "body": "{\"name\": \"king_arthur.txt\"}",
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-type": [
+                        "application/json"
+                    ],
+                    "Content-Length": [
+                        "27"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Content-Length": [
+                        "1989"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:52 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ]
+                },
+                "body": {
+                    "string": "{\"status\":200,\"data\":{\"id\":\"6144738d-4719-4bcb-9574-759c87ba2dda\",\"name\":\"king_arthur.txt\"},\"file_upload_request\":{\"url\":\"https://pubnub-mnemosyne-files-eu-central-1-prd.s3.eu-central-1.amazonaws.com/\",\"method\":\"POST\",\"expiration_date\":\"2023-07-04T19:50:52Z\",\"form_fields\":[{\"key\":\"tagging\",\"value\":\"\\u003cTagging\\u003e\\u003cTagSet\\u003e\\u003cTag\\u003e\\u003cKey\\u003eObjectTTLInDays\\u003c/Key\\u003e\\u003cValue\\u003e1\\u003c/Value\\u003e\\u003c/Tag\\u003e\\u003c/TagSet\\u003e\\u003c/Tagging\\u003e\"},{\"key\":\"key\",\"value\":\"{PN_KEY_SUBSCRIBE}/f-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ/6144738d-4719-4bcb-9574-759c87ba2dda/king_arthur.txt\"},{\"key\":\"Content-Type\",\"value\":\"text/plain; charset=utf-8\"},{\"key\":\"X-Amz-Credential\",\"value\":\"AKIAY7AU6GQDV5LCPVEX/20230704/eu-central-1/s3/aws4_request\"},{\"key\":\"X-Amz-Security-Token\",\"value\":\"\"},{\"key\":\"X-Amz-Algorithm\",\"value\":\"AWS4-HMAC-SHA256\"},{\"key\":\"X-Amz-Date\",\"value\":\"20230704T195052Z\"},{\"key\":\"Policy\",\"value\":\"CnsKCSJleHBpcmF0aW9uIjogIjIwMjMtMDctMDRUMTk6NTA6NTJaIiwKCSJjb25kaXRpb25zIjogWwoJCXsiYnVja2V0IjogInB1Ym51Yi1tbmVtb3N5bmUtZmlsZXMtZXUtY2VudHJhbC0xLXByZCJ9LAoJCVsiZXEiLCAiJHRhZ2dpbmciLCAiPFRhZ2dpbmc+PFRhZ1NldD48VGFnPjxLZXk+T2JqZWN0VFRMSW5EYXlzPC9LZXk+PFZhbHVlPjE8L1ZhbHVlPjwvVGFnPjwvVGFnU2V0PjwvVGFnZ2luZz4iXSwKCQlbImVxIiwgIiRrZXkiLCAic3ViLWMtODhiOWRiYWItMjBmMS00OGQ0LThkZjMtOWJmYWJiMDBjMGI0L2YtdElBY05YSk85bTgxZldWVl9vLWZTUS12ZXVwTnJUbG9WQVVQYmVVUVEvNjE0NDczOGQtNDcxOS00YmNiLTk1NzQtNzU5Yzg3YmEyZGRhL2tpbmdfYXJ0aHVyLnR4dCJdLAoJCVsiY29udGVudC1sZW5ndGgtcmFuZ2UiLCAwLCA1MjQyODgwXSwKCQlbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiIl0sCgkJeyJ4LWFtei1jcmVkZW50aWFsIjogIkFLSUFZN0FVNkdRRFY1TENQVkVYLzIwMjMwNzA0L2V1LWNlbnRyYWwtMS9zMy9hd3M0X3JlcXVlc3QifSwKCQl7IngtYW16LXNlY3VyaXR5LXRva2VuIjogIiJ9LAoJCXsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwKCQl7IngtYW16LWRhdGUiOiAiMjAyMzA3MDRUMTk1MDUyWiIgfQoJXQp9Cg==\"},{\"key\":\"X-Amz-Signature\",\"value\":\"09f9e541b894c0f477295cd13d346f66b0b1ce5252ab18eb3f7afadc63e1896b\"}]}}"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://pubnub-mnemosyne-files-eu-central-1-prd.s3.eu-central-1.amazonaws.com/",
+                "body": {
+                    "binary": "LS04NTk5YTlhOGUyNzgzNjgzYjE0NmI1MTU5NTIyODhmZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJ0YWdnaW5nIg0KDQo8VGFnZ2luZz48VGFnU2V0PjxUYWc+PEtleT5PYmplY3RUVExJbkRheXM8L0tleT48VmFsdWU+MTwvVmFsdWU+PC9UYWc+PC9UYWdTZXQ+PC9UYWdnaW5nPg0KLS04NTk5YTlhOGUyNzgzNjgzYjE0NmI1MTU5NTIyODhmZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJrZXkiDQoNCnN1Yi1jLTg4YjlkYmFiLTIwZjEtNDhkNC04ZGYzLTliZmFiYjAwYzBiNC9mLXRJQWNOWEpPOW04MWZXVlZfby1mU1EtdmV1cE5yVGxvVkFVUGJlVVFRLzYxNDQ3MzhkLTQ3MTktNGJjYi05NTc0LTc1OWM4N2JhMmRkYS9raW5nX2FydGh1ci50eHQNCi0tODU5OWE5YThlMjc4MzY4M2IxNDZiNTE1OTUyMjg4ZmQNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iQ29udGVudC1UeXBlIg0KDQp0ZXh0L3BsYWluOyBjaGFyc2V0PXV0Zi04DQotLTg1OTlhOWE4ZTI3ODM2ODNiMTQ2YjUxNTk1MjI4OGZkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9IlgtQW16LUNyZWRlbnRpYWwiDQoNCkFLSUFZN0FVNkdRRFY1TENQVkVYLzIwMjMwNzA0L2V1LWNlbnRyYWwtMS9zMy9hd3M0X3JlcXVlc3QNCi0tODU5OWE5YThlMjc4MzY4M2IxNDZiNTE1OTUyMjg4ZmQNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iWC1BbXotU2VjdXJpdHktVG9rZW4iDQoNCg0KLS04NTk5YTlhOGUyNzgzNjgzYjE0NmI1MTU5NTIyODhmZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJYLUFtei1BbGdvcml0aG0iDQoNCkFXUzQtSE1BQy1TSEEyNTYNCi0tODU5OWE5YThlMjc4MzY4M2IxNDZiNTE1OTUyMjg4ZmQNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iWC1BbXotRGF0ZSINCg0KMjAyMzA3MDRUMTk1MDUyWg0KLS04NTk5YTlhOGUyNzgzNjgzYjE0NmI1MTU5NTIyODhmZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJQb2xpY3kiDQoNCkNuc0tDU0psZUhCcGNtRjBhVzl1SWpvZ0lqSXdNak10TURjdE1EUlVNVGs2TlRBNk5USmFJaXdLQ1NKamIyNWthWFJwYjI1eklqb2dXd29KQ1hzaVluVmphMlYwSWpvZ0luQjFZbTUxWWkxdGJtVnRiM041Ym1VdFptbHNaWE10WlhVdFkyVnVkSEpoYkMweExYQnlaQ0o5TEFvSkNWc2laWEVpTENBaUpIUmhaMmRwYm1jaUxDQWlQRlJoWjJkcGJtYytQRlJoWjFObGRENDhWR0ZuUGp4TFpYaytUMkpxWldOMFZGUk1TVzVFWVhselBDOUxaWGsrUEZaaGJIVmxQakU4TDFaaGJIVmxQand2VkdGblBqd3ZWR0ZuVTJWMFBqd3ZWR0ZuWjJsdVp6NGlYU3dLQ1FsYkltVnhJaXdnSWlSclpYa2lMQ0FpYzNWaUxXTXRPRGhpT1dSaVlXSXRNakJtTVMwME9HUTBMVGhrWmpNdE9XSm1ZV0ppTURCak1HSTBMMll0ZEVsQlkwNVlTazg1YlRneFpsZFdWbDl2TFdaVFVTMTJaWFZ3VG5KVWJHOVdRVlZRWW1WVlVWRXZOakUwTkRjek9HUXRORGN4T1MwMFltTmlMVGsxTnpRdE56VTVZemczWW1FeVpHUmhMMnRwYm1kZllYSjBhSFZ5TG5SNGRDSmRMQW9KQ1ZzaVkyOXVkR1Z1ZEMxc1pXNW5kR2d0Y21GdVoyVWlMQ0F3TENBMU1qUXlPRGd3WFN3S0NRbGJJbk4wWVhKMGN5MTNhWFJvSWl3Z0lpUkRiMjUwWlc1MExWUjVjR1VpTENBaUlsMHNDZ2tKZXlKNExXRnRlaTFqY21Wa1pXNTBhV0ZzSWpvZ0lrRkxTVUZaTjBGVk5rZFJSRlkxVEVOUVZrVllMekl3TWpNd056QTBMMlYxTFdObGJuUnlZV3d0TVM5ek15OWhkM00wWDNKbGNYVmxjM1FpZlN3S0NRbDdJbmd0WVcxNkxYTmxZM1Z5YVhSNUxYUnZhMlZ1SWpvZ0lpSjlMQW9KQ1hzaWVDMWhiWG90WVd4bmIzSnBkR2h0SWpvZ0lrRlhVelF0U0UxQlF5MVRTRUV5TlRZaWZTd0tDUWw3SW5ndFlXMTZMV1JoZEdVaU9pQWlNakF5TXpBM01EUlVNVGsxTURVeVdpSWdmUW9KWFFwOUNnPT0NCi0tODU5OWE5YThlMjc4MzY4M2IxNDZiNTE1OTUyMjg4ZmQNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iWC1BbXotU2lnbmF0dXJlIg0KDQowOWY5ZTU0MWI4OTRjMGY0NzcyOTVjZDEzZDM0NmY2NmIwYjFjZTUyNTJhYjE4ZWIzZjdhZmFkYzYzZTE4OTZiDQotLTg1OTlhOWE4ZTI3ODM2ODNiMTQ2YjUxNTk1MjI4OGZkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0ia2luZ19hcnRodXIudHh0Ig0KDQprbmlnaHRzb2ZuaTEyMzQ1eFfV0LUcHPC0jOgZUypICeqERdBWXaUFt/q9yQ87HtENCi0tODU5OWE5YThlMjc4MzY4M2IxNDZiNTE1OTUyMjg4ZmQtLQ0K"
+                },
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "2343"
+                    ],
+                    "Content-Type": [
+                        "multipart/form-data; boundary=8599a9a8e2783683b146b515952288fd"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 204,
+                    "message": "No Content"
+                },
+                "headers": {
+                    "x-amz-expiration": [
+                        "expiry-date=\"Thu, 06 Jul 2023 00:00:00 GMT\", rule-id=\"Archive file 1 day after creation\""
+                    ],
+                    "x-amz-request-id": [
+                        "FG5BVM2Q7DVWN98W"
+                    ],
+                    "ETag": [
+                        "\"31af664ac2b86f242369f06edf9dc460\""
+                    ],
+                    "Server": [
+                        "AmazonS3"
+                    ],
+                    "Location": [
+                        "https://pubnub-mnemosyne-files-eu-central-1-prd.s3.eu-central-1.amazonaws.com/{PN_KEY_SUBSCRIBE}%2Ff-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ%2F6144738d-4719-4bcb-9574-759c87ba2dda%2Fking_arthur.txt"
+                    ],
+                    "x-amz-id-2": [
+                        "O3Aq1zRp/A/AREfBqIqd4D43wUGqk8QMTUZtm+hmUyW4it+CNzdRyYvSHsuO/kFr1JozHbWP/OQ="
+                    ],
+                    "x-amz-server-side-encryption": [
+                        "AES256"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:53 GMT"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://ps.pndsn.com/v1/files/publish-file/{PN_KEY_PUBLISH}/{PN_KEY_SUBSCRIBE}/0/files_native_sync_ch/0/%22a25pZ2h0c29mbmkxMjM0NZRrfJgUztWUV6pXv5zfmA3XciGL8ZdRVe31QyUHau4hbr1JeckbF6Xa4tpO5qF0zbp8T5zlm4YRqSNPOozSZbJK7NBLSrY1XH4sqRMmw9kqbFP0XZ1hkGhwY4A6xz5HK7NJA7AgYYcYNGHC89fuKpkY0O3GF50zbH86R6Jra3YM%22?meta=null&store=1&ttl=222&uuid=uuid-mock",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Cache-Control": [
+                        "no-cache"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/javascript; charset=\"UTF-8\""
+                    ],
+                    "Content-Length": [
+                        "30"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:52 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Access-Control-Allow-Methods": [
+                        "GET"
+                    ]
+                },
+                "body": {
+                    "string": "[1,\"Sent\",\"16885001923916260\"]"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://ps.pndsn.com/v1/files/{PN_KEY_SUBSCRIBE}/channels/files_native_sync_ch/files/6144738d-4719-4bcb-9574-759c87ba2dda/king_arthur.txt?uuid=uuid-mock",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 307,
+                    "message": "Temporary Redirect"
+                },
+                "headers": {
+                    "Cache-Control": [
+                        "public, max-age=848, immutable"
+                    ],
+                    "Location": [
+                        "https://files-eu-central-1.pndsn.com/{PN_KEY_SUBSCRIBE}/f-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ/6144738d-4719-4bcb-9574-759c87ba2dda/king_arthur.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY7AU6GQDV5LCPVEX%2F20230704%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20230704T190000Z&X-Amz-Expires=3900&X-Amz-SignedHeaders=host&X-Amz-Signature=eefac0ff6d196b2e9b7e630e54e2abcecb0ab9b2e954742e3e43d866e373f54e"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:52 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://files-eu-central-1.pndsn.com/{PN_KEY_SUBSCRIBE}/f-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ/6144738d-4719-4bcb-9574-759c87ba2dda/king_arthur.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY7AU6GQDV5LCPVEX%2F20230704%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20230704T190000Z&X-Amz-Expires=3900&X-Amz-Signature=eefac0ff6d196b2e9b7e630e54e2abcecb0ab9b2e954742e3e43d866e373f54e&X-Amz-SignedHeaders=host",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-amz-expiration": [
+                        "expiry-date=\"Thu, 06 Jul 2023 00:00:00 GMT\", rule-id=\"Archive file 1 day after creation\""
+                    ],
+                    "x-amz-server-side-encryption": [
+                        "AES256"
+                    ],
+                    "X-Amz-Cf-Id": [
+                        "0su1Z_4V03uqmqXkurjllb3XWVKGorOUeSRzacQRIsQfEadHeyI-Sg=="
+                    ],
+                    "Accept-Ranges": [
+                        "bytes"
+                    ],
+                    "Via": [
+                        "1.1 116bbd3369f3a47b2d68a49a57fa7b40.cloudfront.net (CloudFront)"
+                    ],
+                    "ETag": [
+                        "\"31af664ac2b86f242369f06edf9dc460\""
+                    ],
+                    "Server": [
+                        "AmazonS3"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/plain; charset=utf-8"
+                    ],
+                    "Last-Modified": [
+                        "Tue, 04 Jul 2023 19:49:53 GMT"
+                    ],
+                    "X-Amz-Cf-Pop": [
+                        "WAW51-P3"
+                    ],
+                    "X-Cache": [
+                        "Miss from cloudfront"
+                    ],
+                    "Content-Length": [
+                        "48"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:53 GMT"
+                    ]
+                },
+                "body": {
+                    "binary": "a25pZ2h0c29mbmkxMjM0NXhX1dC1HBzwtIzoGVMqSAnqhEXQVl2lBbf6vckPOx7R"
+                }
+            }
+        }
+    ]
+}

--- a/tests/integrational/fixtures/native_sync/file_upload/send_and_download_gcm_encrypted_file.json
+++ b/tests/integrational/fixtures/native_sync/file_upload/send_and_download_gcm_encrypted_file.json
@@ -1,0 +1,299 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://ps.pndsn.com/v1/files/{PN_KEY_SUBSCRIBE}/channels/files_native_sync_ch/generate-upload-url?uuid=uuid-mock",
+                "body": "{\"name\": \"king_arthur.txt\"}",
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-type": [
+                        "application/json"
+                    ],
+                    "Content-Length": [
+                        "27"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "application/json"
+                    ],
+                    "Content-Length": [
+                        "1989"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:51 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ]
+                },
+                "body": {
+                    "string": "{\"status\":200,\"data\":{\"id\":\"4c8364f9-3d47-4196-8b0a-d1311a97e8d1\",\"name\":\"king_arthur.txt\"},\"file_upload_request\":{\"url\":\"https://pubnub-mnemosyne-files-eu-central-1-prd.s3.eu-central-1.amazonaws.com/\",\"method\":\"POST\",\"expiration_date\":\"2023-07-04T19:50:51Z\",\"form_fields\":[{\"key\":\"tagging\",\"value\":\"\\u003cTagging\\u003e\\u003cTagSet\\u003e\\u003cTag\\u003e\\u003cKey\\u003eObjectTTLInDays\\u003c/Key\\u003e\\u003cValue\\u003e1\\u003c/Value\\u003e\\u003c/Tag\\u003e\\u003c/TagSet\\u003e\\u003c/Tagging\\u003e\"},{\"key\":\"key\",\"value\":\"{PN_KEY_SUBSCRIBE}/f-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ/4c8364f9-3d47-4196-8b0a-d1311a97e8d1/king_arthur.txt\"},{\"key\":\"Content-Type\",\"value\":\"text/plain; charset=utf-8\"},{\"key\":\"X-Amz-Credential\",\"value\":\"AKIAY7AU6GQDV5LCPVEX/20230704/eu-central-1/s3/aws4_request\"},{\"key\":\"X-Amz-Security-Token\",\"value\":\"\"},{\"key\":\"X-Amz-Algorithm\",\"value\":\"AWS4-HMAC-SHA256\"},{\"key\":\"X-Amz-Date\",\"value\":\"20230704T195051Z\"},{\"key\":\"Policy\",\"value\":\"CnsKCSJleHBpcmF0aW9uIjogIjIwMjMtMDctMDRUMTk6NTA6NTFaIiwKCSJjb25kaXRpb25zIjogWwoJCXsiYnVja2V0IjogInB1Ym51Yi1tbmVtb3N5bmUtZmlsZXMtZXUtY2VudHJhbC0xLXByZCJ9LAoJCVsiZXEiLCAiJHRhZ2dpbmciLCAiPFRhZ2dpbmc+PFRhZ1NldD48VGFnPjxLZXk+T2JqZWN0VFRMSW5EYXlzPC9LZXk+PFZhbHVlPjE8L1ZhbHVlPjwvVGFnPjwvVGFnU2V0PjwvVGFnZ2luZz4iXSwKCQlbImVxIiwgIiRrZXkiLCAic3ViLWMtODhiOWRiYWItMjBmMS00OGQ0LThkZjMtOWJmYWJiMDBjMGI0L2YtdElBY05YSk85bTgxZldWVl9vLWZTUS12ZXVwTnJUbG9WQVVQYmVVUVEvNGM4MzY0ZjktM2Q0Ny00MTk2LThiMGEtZDEzMTFhOTdlOGQxL2tpbmdfYXJ0aHVyLnR4dCJdLAoJCVsiY29udGVudC1sZW5ndGgtcmFuZ2UiLCAwLCA1MjQyODgwXSwKCQlbInN0YXJ0cy13aXRoIiwgIiRDb250ZW50LVR5cGUiLCAiIl0sCgkJeyJ4LWFtei1jcmVkZW50aWFsIjogIkFLSUFZN0FVNkdRRFY1TENQVkVYLzIwMjMwNzA0L2V1LWNlbnRyYWwtMS9zMy9hd3M0X3JlcXVlc3QifSwKCQl7IngtYW16LXNlY3VyaXR5LXRva2VuIjogIiJ9LAoJCXsieC1hbXotYWxnb3JpdGhtIjogIkFXUzQtSE1BQy1TSEEyNTYifSwKCQl7IngtYW16LWRhdGUiOiAiMjAyMzA3MDRUMTk1MDUxWiIgfQoJXQp9Cg==\"},{\"key\":\"X-Amz-Signature\",\"value\":\"ca3764c9c3cdf3be6d9fda3d53e2ab74f125abf70cb41110450ac101fb55ff68\"}]}}"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "POST",
+                "uri": "https://pubnub-mnemosyne-files-eu-central-1-prd.s3.eu-central-1.amazonaws.com/",
+                "body": {
+                    "binary": "LS0zMzRhYmM0MTAyMzEwODE4ZWUxNTAyODJiNTRjNTYwOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJ0YWdnaW5nIg0KDQo8VGFnZ2luZz48VGFnU2V0PjxUYWc+PEtleT5PYmplY3RUVExJbkRheXM8L0tleT48VmFsdWU+MTwvVmFsdWU+PC9UYWc+PC9UYWdTZXQ+PC9UYWdnaW5nPg0KLS0zMzRhYmM0MTAyMzEwODE4ZWUxNTAyODJiNTRjNTYwOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJrZXkiDQoNCnN1Yi1jLTg4YjlkYmFiLTIwZjEtNDhkNC04ZGYzLTliZmFiYjAwYzBiNC9mLXRJQWNOWEpPOW04MWZXVlZfby1mU1EtdmV1cE5yVGxvVkFVUGJlVVFRLzRjODM2NGY5LTNkNDctNDE5Ni04YjBhLWQxMzExYTk3ZThkMS9raW5nX2FydGh1ci50eHQNCi0tMzM0YWJjNDEwMjMxMDgxOGVlMTUwMjgyYjU0YzU2MDkNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iQ29udGVudC1UeXBlIg0KDQp0ZXh0L3BsYWluOyBjaGFyc2V0PXV0Zi04DQotLTMzNGFiYzQxMDIzMTA4MThlZTE1MDI4MmI1NGM1NjA5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9IlgtQW16LUNyZWRlbnRpYWwiDQoNCkFLSUFZN0FVNkdRRFY1TENQVkVYLzIwMjMwNzA0L2V1LWNlbnRyYWwtMS9zMy9hd3M0X3JlcXVlc3QNCi0tMzM0YWJjNDEwMjMxMDgxOGVlMTUwMjgyYjU0YzU2MDkNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iWC1BbXotU2VjdXJpdHktVG9rZW4iDQoNCg0KLS0zMzRhYmM0MTAyMzEwODE4ZWUxNTAyODJiNTRjNTYwOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJYLUFtei1BbGdvcml0aG0iDQoNCkFXUzQtSE1BQy1TSEEyNTYNCi0tMzM0YWJjNDEwMjMxMDgxOGVlMTUwMjgyYjU0YzU2MDkNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iWC1BbXotRGF0ZSINCg0KMjAyMzA3MDRUMTk1MDUxWg0KLS0zMzRhYmM0MTAyMzEwODE4ZWUxNTAyODJiNTRjNTYwOQ0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJQb2xpY3kiDQoNCkNuc0tDU0psZUhCcGNtRjBhVzl1SWpvZ0lqSXdNak10TURjdE1EUlVNVGs2TlRBNk5URmFJaXdLQ1NKamIyNWthWFJwYjI1eklqb2dXd29KQ1hzaVluVmphMlYwSWpvZ0luQjFZbTUxWWkxdGJtVnRiM041Ym1VdFptbHNaWE10WlhVdFkyVnVkSEpoYkMweExYQnlaQ0o5TEFvSkNWc2laWEVpTENBaUpIUmhaMmRwYm1jaUxDQWlQRlJoWjJkcGJtYytQRlJoWjFObGRENDhWR0ZuUGp4TFpYaytUMkpxWldOMFZGUk1TVzVFWVhselBDOUxaWGsrUEZaaGJIVmxQakU4TDFaaGJIVmxQand2VkdGblBqd3ZWR0ZuVTJWMFBqd3ZWR0ZuWjJsdVp6NGlYU3dLQ1FsYkltVnhJaXdnSWlSclpYa2lMQ0FpYzNWaUxXTXRPRGhpT1dSaVlXSXRNakJtTVMwME9HUTBMVGhrWmpNdE9XSm1ZV0ppTURCak1HSTBMMll0ZEVsQlkwNVlTazg1YlRneFpsZFdWbDl2TFdaVFVTMTJaWFZ3VG5KVWJHOVdRVlZRWW1WVlVWRXZOR000TXpZMFpqa3RNMlEwTnkwME1UazJMVGhpTUdFdFpERXpNVEZoT1RkbE9HUXhMMnRwYm1kZllYSjBhSFZ5TG5SNGRDSmRMQW9KQ1ZzaVkyOXVkR1Z1ZEMxc1pXNW5kR2d0Y21GdVoyVWlMQ0F3TENBMU1qUXlPRGd3WFN3S0NRbGJJbk4wWVhKMGN5MTNhWFJvSWl3Z0lpUkRiMjUwWlc1MExWUjVjR1VpTENBaUlsMHNDZ2tKZXlKNExXRnRlaTFqY21Wa1pXNTBhV0ZzSWpvZ0lrRkxTVUZaTjBGVk5rZFJSRlkxVEVOUVZrVllMekl3TWpNd056QTBMMlYxTFdObGJuUnlZV3d0TVM5ek15OWhkM00wWDNKbGNYVmxjM1FpZlN3S0NRbDdJbmd0WVcxNkxYTmxZM1Z5YVhSNUxYUnZhMlZ1SWpvZ0lpSjlMQW9KQ1hzaWVDMWhiWG90WVd4bmIzSnBkR2h0SWpvZ0lrRlhVelF0U0UxQlF5MVRTRUV5TlRZaWZTd0tDUWw3SW5ndFlXMTZMV1JoZEdVaU9pQWlNakF5TXpBM01EUlVNVGsxTURVeFdpSWdmUW9KWFFwOUNnPT0NCi0tMzM0YWJjNDEwMjMxMDgxOGVlMTUwMjgyYjU0YzU2MDkNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0iWC1BbXotU2lnbmF0dXJlIg0KDQpjYTM3NjRjOWMzY2RmM2JlNmQ5ZmRhM2Q1M2UyYWI3NGYxMjVhYmY3MGNiNDExMTA0NTBhYzEwMWZiNTVmZjY4DQotLTMzNGFiYzQxMDIzMTA4MThlZTE1MDI4MmI1NGM1NjA5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0ia2luZ19hcnRodXIudHh0Ig0KDQprbmlnaHRzb2ZuaTEyMzQ1WROoIL5+mIcDLrFsD1pXILAs96HbdvkteQfzeLPZFVoNCi0tMzM0YWJjNDEwMjMxMDgxOGVlMTUwMjgyYjU0YzU2MDktLQ0K"
+                },
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "2343"
+                    ],
+                    "Content-Type": [
+                        "multipart/form-data; boundary=334abc4102310818ee150282b54c5609"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 204,
+                    "message": "No Content"
+                },
+                "headers": {
+                    "x-amz-expiration": [
+                        "expiry-date=\"Thu, 06 Jul 2023 00:00:00 GMT\", rule-id=\"Archive file 1 day after creation\""
+                    ],
+                    "x-amz-request-id": [
+                        "HGJZYD4BKZEXHRBD"
+                    ],
+                    "ETag": [
+                        "\"34becf969765be57d7444e86655ba3e1\""
+                    ],
+                    "Server": [
+                        "AmazonS3"
+                    ],
+                    "Location": [
+                        "https://pubnub-mnemosyne-files-eu-central-1-prd.s3.eu-central-1.amazonaws.com/{PN_KEY_SUBSCRIBE}%2Ff-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ%2F4c8364f9-3d47-4196-8b0a-d1311a97e8d1%2Fking_arthur.txt"
+                    ],
+                    "x-amz-id-2": [
+                        "v60LspWXjLjtaBRzmZXEXtOEAwxw7u5UbfYoUn6Fab0jm9Y/i7ShapdWHe8L9a1anirQ5xPkyW0="
+                    ],
+                    "x-amz-server-side-encryption": [
+                        "AES256"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:52 GMT"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://ps.pndsn.com/v1/files/publish-file/{PN_KEY_PUBLISH}/{PN_KEY_SUBSCRIBE}/0/files_native_sync_ch/0/%22a25pZ2h0c29mbmkxMjM0NWlfrCKleYrAEWTkbAcZWmWNMYnBswiHQRNv3E%2Be9mwyA7pQMEzjEBgkyw0%2B5u%2BMOCRsrIyMqQV18bKtl18kvhtrPqmYunT84n9djZ2Vlo%2FNliZ29yx8TVeeI1YJxS3fdJ9%2FPwVKuA51%2BmfdRA2DcgsOBlkmMsBka4Yj%2Fl0nVbOk%22?meta=null&store=1&ttl=222&uuid=uuid-mock",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Cache-Control": [
+                        "no-cache"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/javascript; charset=\"UTF-8\""
+                    ],
+                    "Content-Length": [
+                        "30"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:51 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Access-Control-Allow-Methods": [
+                        "GET"
+                    ]
+                },
+                "body": {
+                    "string": "[1,\"Sent\",\"16885001917892621\"]"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://ps.pndsn.com/v1/files/{PN_KEY_SUBSCRIBE}/channels/files_native_sync_ch/files/4c8364f9-3d47-4196-8b0a-d1311a97e8d1/king_arthur.txt?uuid=uuid-mock",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 307,
+                    "message": "Temporary Redirect"
+                },
+                "headers": {
+                    "Cache-Control": [
+                        "public, max-age=849, immutable"
+                    ],
+                    "Location": [
+                        "https://files-eu-central-1.pndsn.com/{PN_KEY_SUBSCRIBE}/f-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ/4c8364f9-3d47-4196-8b0a-d1311a97e8d1/king_arthur.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY7AU6GQDV5LCPVEX%2F20230704%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20230704T190000Z&X-Amz-Expires=3900&X-Amz-SignedHeaders=host&X-Amz-Signature=53ddeccd7481586b498b8d52a3fca1cc3c509ee0e4db75114bdda960f42ad66a"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:51 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ]
+                },
+                "body": {
+                    "string": ""
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://files-eu-central-1.pndsn.com/{PN_KEY_SUBSCRIBE}/f-tIAcNXJO9m81fWVV_o-fSQ-veupNrTloVAUPbeUQQ/4c8364f9-3d47-4196-8b0a-d1311a97e8d1/king_arthur.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY7AU6GQDV5LCPVEX%2F20230704%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20230704T190000Z&X-Amz-Expires=3900&X-Amz-Signature=53ddeccd7481586b498b8d52a3fca1cc3c509ee0e4db75114bdda960f42ad66a&X-Amz-SignedHeaders=host",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.1.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-amz-expiration": [
+                        "expiry-date=\"Thu, 06 Jul 2023 00:00:00 GMT\", rule-id=\"Archive file 1 day after creation\""
+                    ],
+                    "x-amz-server-side-encryption": [
+                        "AES256"
+                    ],
+                    "X-Amz-Cf-Id": [
+                        "pq8WX-lwob2MNiiVsHdZjXEKD2YxDtB-BxS5KqG129X5DH-IN0-KBw=="
+                    ],
+                    "Accept-Ranges": [
+                        "bytes"
+                    ],
+                    "Via": [
+                        "1.1 cffe8a62b982ad6d295e862637dbfaf2.cloudfront.net (CloudFront)"
+                    ],
+                    "ETag": [
+                        "\"34becf969765be57d7444e86655ba3e1\""
+                    ],
+                    "Server": [
+                        "AmazonS3"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/plain; charset=utf-8"
+                    ],
+                    "Last-Modified": [
+                        "Tue, 04 Jul 2023 19:49:52 GMT"
+                    ],
+                    "X-Amz-Cf-Pop": [
+                        "WAW51-P3"
+                    ],
+                    "X-Cache": [
+                        "Miss from cloudfront"
+                    ],
+                    "Content-Length": [
+                        "48"
+                    ],
+                    "Date": [
+                        "Tue, 04 Jul 2023 19:49:52 GMT"
+                    ]
+                },
+                "body": {
+                    "binary": "a25pZ2h0c29mbmkxMjM0NVkTqCC+fpiHAy6xbA9aVyCwLPeh23b5LXkH83iz2RVa"
+                }
+            }
+        }
+    ]
+}

--- a/tests/integrational/vcr_serializer.py
+++ b/tests/integrational/vcr_serializer.py
@@ -23,25 +23,23 @@ class PNSerializer:
     def serialize(self, cassette_dict):
         for index, interaction in enumerate(cassette_dict['interactions']):
             # for serializing binary body
+            if type(interaction['request']['body']) is bytes:
+                ascii_body = b64encode(interaction['request']['body']).decode('ascii')
+                interaction['request']['body'] = {'binary': ascii_body}
             if type(interaction['response']['body']['string']) is bytes:
                 ascii_body = b64encode(interaction['response']['body']['string']).decode('ascii')
                 interaction['response']['body'] = {'binary': ascii_body}
 
-            interaction['request']['uri'] = self.replace_keys(interaction['request']['uri'])
-            cassette_dict['interactions'][index] == interaction
-        return serialize(cassette_dict)
+        return self.replace_keys(serialize(cassette_dict))
 
-    def replace_placeholders(self, interaction_dict):
+    def replace_placeholders(self, cassette_string):
         for key in self.envs.keys():
-            interaction_dict['request']['uri'] = re.sub(f'{{{key}}}',
-                                                        self.envs[key],
-                                                        interaction_dict['request']['uri'])
-        return interaction_dict
+            cassette_string = re.sub(f'{{{key}}}', self.envs[key], cassette_string)
+        return cassette_string
 
     def deserialize(self, cassette_string):
-        cassette_dict = deserialize(cassette_string)
+        cassette_dict = deserialize(self.replace_placeholders(cassette_string))
         for index, interaction in enumerate(cassette_dict['interactions']):
-            interaction = self.replace_placeholders(interaction)
             if 'binary' in interaction['response']['body'].keys():
                 interaction['response']['body']['string'] = b64decode(interaction['response']['body']['binary'])
                 del interaction['response']['body']['binary']


### PR DESCRIPTION
feat: Option to change the ciphering method

Introduced option to select ciphering method for encoding messages and files. The default behavior is unchanged. More can be read [in this comment](https://github.com/pubnub/python/pull/156#issuecomment-1623307799)
