### PR TITLE
Handle exception on history unencrypted message

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: python
-version: 7.3.1
+version: 7.3.2
 schema: 1
 scm: github.com/pubnub/python
 sdks:
@@ -18,7 +18,7 @@ sdks:
         distributions:
           - distribution-type: library
             distribution-repository: package
-            package-name: pubnub-7.3.1
+            package-name: pubnub-7.3.2
             location: https://pypi.org/project/pubnub/
             supported-platforms:
               supported-operating-systems:
@@ -97,8 +97,8 @@ sdks:
           -
             distribution-type: library
             distribution-repository: git release
-            package-name: pubnub-7.3.1
-            location: https://github.com/pubnub/python/releases/download/v7.3.1/pubnub-7.3.1.tar.gz
+            package-name: pubnub-7.3.2
+            location: https://github.com/pubnub/python/releases/download/v7.3.2/pubnub-7.3.2.tar.gz
             supported-platforms:
               supported-operating-systems:
                 Linux:
@@ -169,6 +169,11 @@ sdks:
                 license-url: https://github.com/aio-libs/aiohttp/blob/master/LICENSE.txt
                 is-required: Required
 changelog:
+  - date: 2023-11-27
+    version: v7.3.2
+    changes:
+      - type: bug
+        text: "Gracefully handle decrypting an unencrypted method. If a decryption error occurs when trying to decrypt plain text, the plain text message will be returned and an error field will be set in the response. This works for both history and subscription messages."
   - date: 2023-10-30
     version: v7.3.1
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v7.3.2
+November 27 2023
+
+#### Fixed
+- Gracefully handle decrypting an unencrypted method. If a decryption error occurs when trying to decrypt plain text, the plain text message will be returned and an error field will be set in the response. This works for both history and subscription messages.
+
 ## v7.3.1
 October 30 2023
 

--- a/pubnub/models/consumer/history.py
+++ b/pubnub/models/consumer/history.py
@@ -1,3 +1,6 @@
+import binascii
+
+
 class PNHistoryResult(object):
     def __init__(self, messages, start_timetoken, end_timetoken):
         self.messages = messages
@@ -44,12 +47,16 @@ class PNHistoryItemResult(object):
         self.meta = meta
         self.entry = entry
         self.crypto = crypto
+        self.error = None
 
     def __str__(self):
         return "History item with tt: %s and content: %s" % (self.timetoken, self.entry)
 
     def decrypt(self, cipher_key):
-        self.entry = self.crypto.decrypt(cipher_key, self.entry)
+        try:
+            self.entry = self.crypto.decrypt(cipher_key, self.entry)
+        except binascii.Error as e:
+            self.error = e
 
 
 class PNFetchMessagesResult(object):

--- a/pubnub/models/consumer/pubsub.py
+++ b/pubnub/models/consumer/pubsub.py
@@ -2,7 +2,7 @@ from pubnub.models.consumer.message_actions import PNMessageAction
 
 
 class PNMessageResult(object):
-    def __init__(self, message, subscription, channel, timetoken, user_metadata=None, publisher=None):
+    def __init__(self, message, subscription, channel, timetoken, user_metadata=None, publisher=None, error=None):
 
         if subscription is not None:
             assert isinstance(subscription, str)
@@ -29,6 +29,7 @@ class PNMessageResult(object):
         self.timetoken = timetoken
         self.user_metadata = user_metadata
         self.publisher = publisher
+        self.error = error
 
 
 class PNSignalMessageResult(PNMessageResult):

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -85,7 +85,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "7.3.1"
+    SDK_VERSION = "7.3.2"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='7.3.1',
+    version='7.3.2',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',

--- a/tests/integrational/fixtures/native_sync/history/unencrypted.json
+++ b/tests/integrational/fixtures/native_sync/history/unencrypted.json
@@ -1,0 +1,185 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "DELETE",
+                "uri": "https://ps.pndsn.com/v3/history/sub-key/{PN_KEY_SUBSCRIBE}/channel/test_unencrypted",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.3.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Length": [
+                        "0"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Age": [
+                        "0"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/javascript; charset=\"UTF-8\""
+                    ],
+                    "Content-Length": [
+                        "52"
+                    ],
+                    "Cache-Control": [
+                        "no-cache"
+                    ],
+                    "Server": [
+                        "Pubnub Storage"
+                    ],
+                    "Date": [
+                        "Wed, 22 Nov 2023 15:33:23 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Access-Control-Allow-Methods": [
+                        "GET, POST, DELETE, OPTIONS"
+                    ],
+                    "Accept-Ranges": [
+                        "bytes"
+                    ]
+                },
+                "body": {
+                    "string": "{\"status\": 200, \"error\": false, \"error_message\": \"\"}"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://ps.pndsn.com/publish/{PN_KEY_PUBLISH}/{PN_KEY_SUBSCRIBE}/0/test_unencrypted/0/%22Lorem%20Ipsum%22?seqn=1",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.3.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/javascript; charset=\"UTF-8\""
+                    ],
+                    "Content-Length": [
+                        "30"
+                    ],
+                    "Cache-Control": [
+                        "no-cache"
+                    ],
+                    "Date": [
+                        "Wed, 22 Nov 2023 15:33:23 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Access-Control-Allow-Methods": [
+                        "GET"
+                    ]
+                },
+                "body": {
+                    "string": "[1,\"Sent\",\"17006672033304156\"]"
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://ps.pndsn.com/v2/history/sub-key/{PN_KEY_SUBSCRIBE}/channel/test_unencrypted?count=100",
+                "body": null,
+                "headers": {
+                    "User-Agent": [
+                        "PubNub-Python/7.3.0"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ]
+                }
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "Age": [
+                        "0"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/javascript; charset=\"UTF-8\""
+                    ],
+                    "Content-Length": [
+                        "53"
+                    ],
+                    "Cache-Control": [
+                        "no-cache"
+                    ],
+                    "Server": [
+                        "Pubnub Storage"
+                    ],
+                    "Date": [
+                        "Wed, 22 Nov 2023 15:33:25 GMT"
+                    ],
+                    "Access-Control-Allow-Origin": [
+                        "*"
+                    ],
+                    "Access-Control-Allow-Methods": [
+                        "GET, POST, DELETE, OPTIONS"
+                    ],
+                    "Accept-Ranges": [
+                        "bytes"
+                    ]
+                },
+                "body": {
+                    "string": "[[\"Lorem Ipsum\"],17006672033304156,17006672033304156]"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
fix: Gracefully handle decrypting an unencrypted method. If a decryption error occurs when trying to decrypt plain text, the plain text message will be returned and an error field will be set in the response. This works for both history and subscription messages.