### PR TITLE
Example - How to check SDK version

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: python
-version: 7.4.2
+version: 7.4.3
 schema: 1
 scm: github.com/pubnub/python
 sdks:
@@ -18,7 +18,7 @@ sdks:
         distributions:
           - distribution-type: library
             distribution-repository: package
-            package-name: pubnub-7.4.2
+            package-name: pubnub-7.4.3
             location: https://pypi.org/project/pubnub/
             supported-platforms:
               supported-operating-systems:
@@ -97,8 +97,8 @@ sdks:
           -
             distribution-type: library
             distribution-repository: git release
-            package-name: pubnub-7.4.2
-            location: https://github.com/pubnub/python/releases/download/v7.4.2/pubnub-7.4.2.tar.gz
+            package-name: pubnub-7.4.3
+            location: https://github.com/pubnub/python/releases/download/v7.4.3/pubnub-7.4.3.tar.gz
             supported-platforms:
               supported-operating-systems:
                 Linux:
@@ -169,6 +169,11 @@ sdks:
                 license-url: https://github.com/aio-libs/aiohttp/blob/master/LICENSE.txt
                 is-required: Required
 changelog:
+  - date: 2024-03-28
+    version: v7.4.3
+    changes:
+      - type: bug
+        text: "Fixes in the thread based subscription managers causing to duplicate subscription calls."
   - date: 2024-03-07
     version: v7.4.2
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v7.4.3
+March 28 2024
+
+#### Fixed
+- Fixes in the thread based subscription managers causing to duplicate subscription calls.
+
 ## v7.4.2
 March 07 2024
 

--- a/examples/check_sdk_version.py
+++ b/examples/check_sdk_version.py
@@ -1,0 +1,3 @@
+from pubnub.pubnub import PubNub
+
+print(PubNub.SDK_VERSION)

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -85,7 +85,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "7.4.2"
+    SDK_VERSION = "7.4.3"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='7.4.2',
+    version='7.4.3',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',


### PR DESCRIPTION
fix: Fixes in the thread based subscription managers causing to duplicate subscription calls