### PR TITLE
Add type hints to customer facing interfaces

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: python
-version: 8.1.0
+version: 9.0.0
 schema: 1
 scm: github.com/pubnub/python
 sdks:
@@ -18,7 +18,7 @@ sdks:
         distributions:
           - distribution-type: library
             distribution-repository: package
-            package-name: pubnub-8.1.0
+            package-name: pubnub-9.0.0
             location: https://pypi.org/project/pubnub/
             supported-platforms:
               supported-operating-systems:
@@ -97,8 +97,8 @@ sdks:
           -
             distribution-type: library
             distribution-repository: git release
-            package-name: pubnub-8.1.0
-            location: https://github.com/pubnub/python/releases/download/v8.1.0/pubnub-8.1.0.tar.gz
+            package-name: pubnub-9.0.0
+            location: https://github.com/pubnub/python/releases/download/v9.0.0/pubnub-9.0.0.tar.gz
             supported-platforms:
               supported-operating-systems:
                 Linux:
@@ -169,6 +169,19 @@ sdks:
                 license-url: https://github.com/aio-libs/aiohttp/blob/master/LICENSE.txt
                 is-required: Required
 changelog:
+  - date: 2024-10-02
+    version: v9.0.0
+    changes:
+      - type: feature
+        text: "BREAKING CHANGES: Automatic reconnecting for subscribe with exponential backoff is now enabled by default."
+      - type: feature
+        text: "Access manager v2 endpoints (grant and audit) will no longer be supported after December 31, 2024, and will be removed without further notice. Refer to the documentation to learn more."
+      - type: feature
+        text: "BREAKING CHANGES: Once used to instantiate PubNub, the configuration object (PNConfiguration instance) becomes immutable. You will receive exceptions if you rely on modifying the configuration after the PubNub instance is created. Refer to the documentation to learn more."
+      - type: improvement
+        text: "Type hints for parameters and return values are now added to provide a better developer experience."
+      - type: improvement
+        text: "All endpoints are now accessible through the builder pattern and named parameters, providing a more flexible experience suitable for custom solutions."
   - date: 2024-08-13
     version: v8.1.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v9.0.0
+October 02 2024
+
+#### Added
+- BREAKING CHANGES: Automatic reconnecting for subscribe with exponential backoff is now enabled by default.
+- Access manager v2 endpoints (grant and audit) will no longer be supported after December 31, 2024, and will be removed without further notice. Refer to the documentation to learn more.
+- BREAKING CHANGES: Once used to instantiate PubNub, the configuration object (PNConfiguration instance) becomes immutable. You will receive exceptions if you rely on modifying the configuration after the PubNub instance is created. Refer to the documentation to learn more.
+
+#### Modified
+- Type hints for parameters and return values are now added to provide a better developer experience.
+- All endpoints are now accessible through the builder pattern and named parameters, providing a more flexible experience suitable for custom solutions.
+
 ## v8.1.0
 August 13 2024
 

--- a/pubnub/endpoints/access/grant_token.py
+++ b/pubnub/endpoints/access/grant_token.py
@@ -124,8 +124,8 @@ class GrantToken(Endpoint):
     def create_response(self, envelope) -> PNGrantTokenResult:
         return PNGrantTokenResult.from_json(envelope['data'])
 
-    def sync(self):
-        return super().sync()
+    def sync(self) -> PNGrantTokenResultEnvelope:
+        return PNGrantTokenResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return False

--- a/pubnub/endpoints/access/grant_token.py
+++ b/pubnub/endpoints/access/grant_token.py
@@ -1,58 +1,77 @@
+from typing import Union, List, Optional
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_TTL_MISSING, PNERR_INVALID_META, PNERR_RESOURCES_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.v3.access_manager import PNGrantTokenResult
+from pubnub.structures import Envelope
+
+
+class PNGrantTokenResultEnvelope(Envelope):
+    result: PNGrantTokenResult
+    status: PNStatus
 
 
 class GrantToken(Endpoint):
     GRANT_TOKEN_PATH = "/v3/pam/%s/grant"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                 users: Union[str, List[str]] = None, spaces: Union[str, List[str]] = None,
+                 authorized_user_id: str = None, ttl: Optional[int] = None, meta: Optional[any] = None):
         Endpoint.__init__(self, pubnub)
-        self._ttl = None
-        self._meta = None
-        self._authorized_uuid = None
+        self._ttl = ttl
+        self._meta = meta
+        self._authorized_uuid = authorized_user_id
         self._channels = []
+        if channels:
+            utils.extend_list(self._channels, channels)
+        if spaces:
+            utils.extend_list(self._channels, spaces)
+
         self._groups = []
+        if channel_groups:
+            utils.extend_list(self._groups, channel_groups)
         self._uuids = []
+        if users:
+            utils.extend_list(self._uuids, users)
 
         self._sort_params = True
 
-    def ttl(self, ttl):
+    def ttl(self, ttl: int) -> 'GrantToken':
         self._ttl = ttl
         return self
 
-    def meta(self, meta):
+    def meta(self, meta: any) -> 'GrantToken':
         self._meta = meta
         return self
 
-    def authorized_uuid(self, uuid):
+    def authorized_uuid(self, uuid: str) -> 'GrantToken':
         self._authorized_uuid = uuid
         return self
 
-    def authorized_user(self, user):
+    def authorized_user(self, user) -> 'GrantToken':
         self._authorized_uuid = user
         return self
 
-    def spaces(self, spaces):
+    def spaces(self, spaces: Union[str, List[str]]) -> 'GrantToken':
         self._channels = spaces
         return self
 
-    def users(self, users):
+    def users(self, users: Union[str, List[str]]) -> 'GrantToken':
         self._uuids = users
         return self
 
-    def channels(self, channels):
+    def channels(self, channels: Union[str, List[str]]) -> 'GrantToken':
         self._channels = channels
         return self
 
-    def groups(self, groups):
+    def groups(self, groups: Union[str, List[str]]) -> 'GrantToken':
         self._groups = groups
         return self
 
-    def uuids(self, uuids):
+    def uuids(self, uuids: Union[str, List[str]]) -> 'GrantToken':
         self._uuids = uuids
         return self
 
@@ -102,8 +121,11 @@ class GrantToken(Endpoint):
         self.validate_ttl()
         self.validate_resources()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGrantTokenResult:
         return PNGrantTokenResult.from_json(envelope['data'])
+
+    def sync(self):
+        return super().sync()
 
     def is_auth_required(self):
         return False

--- a/pubnub/endpoints/access/revoke_token.py
+++ b/pubnub/endpoints/access/revoke_token.py
@@ -1,13 +1,20 @@
 from pubnub.enums import PNOperationType, HttpMethod
 from pubnub.endpoints.endpoint import Endpoint
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.v3.access_manager import PNRevokeTokenResult
 from pubnub import utils
+from pubnub.structures import Envelope
+
+
+class PNRevokeTokenResultEnvelope(Envelope):
+    result: PNRevokeTokenResult
+    status: PNStatus
 
 
 class RevokeToken(Endpoint):
     REVOKE_TOKEN_PATH = "/v3/pam/%s/grant/%s"
 
-    def __init__(self, pubnub, token):
+    def __init__(self, pubnub, token: str):
         Endpoint.__init__(self, pubnub)
         self.token = token
 
@@ -17,6 +24,9 @@ class RevokeToken(Endpoint):
 
     def create_response(self, envelope):
         return PNRevokeTokenResult(envelope)
+
+    def sync(self) -> PNRevokeTokenResultEnvelope:
+        return PNRevokeTokenResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return False

--- a/pubnub/endpoints/channel_groups/add_channel_to_channel_group.py
+++ b/pubnub/endpoints/channel_groups/add_channel_to_channel_group.py
@@ -1,31 +1,36 @@
+from typing import List, Union
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_CHANNELS_MISSING, PNERR_GROUP_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.models.consumer.channel_group import PNChannelGroupsAddChannelResult
+from pubnub.models.consumer.common import PNStatus
+from pubnub.structures import Envelope
+
+
+class PNChannelGroupsAddChannelResultEnvelope(Envelope):
+    result: PNChannelGroupsAddChannelResult
+    status: PNStatus
 
 
 class AddChannelToChannelGroup(Endpoint):
     # /v1/channel-registration/sub-key/<sub_key>/channel-group/<group_name>?add=ch1,ch2
     ADD_PATH = "/v1/channel-registration/sub-key/%s/channel-group/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, channel_group: str = None):
         Endpoint.__init__(self, pubnub)
         self._channels = []
-        self._channel_group = None
-
-    def channels(self, channels):
-        if isinstance(channels, (list, tuple)):
-            self._channels.extend(channels)
-        else:
-            self._channels.extend(utils.split_items(channels))
-
-        return self
-
-    def channel_group(self, channel_group):
+        if channels:
+            utils.extend_list(self._channels, channels)
         self._channel_group = channel_group
 
+    def channels(self, channels) -> 'AddChannelToChannelGroup':
+        utils.extend_list(self._channels, channels)
+        return self
+
+    def channel_group(self, channel_group: str) -> 'AddChannelToChannelGroup':
+        self._channel_group = channel_group
         return self
 
     def custom_params(self):
@@ -50,8 +55,11 @@ class AddChannelToChannelGroup(Endpoint):
     def is_auth_required(self):
         return True
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNChannelGroupsAddChannelResult:
         return PNChannelGroupsAddChannelResult()
+
+    def sync(self):
+        return PNChannelGroupsAddChannelResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/channel_groups/add_channel_to_channel_group.py
+++ b/pubnub/endpoints/channel_groups/add_channel_to_channel_group.py
@@ -58,7 +58,7 @@ class AddChannelToChannelGroup(Endpoint):
     def create_response(self, envelope) -> PNChannelGroupsAddChannelResult:
         return PNChannelGroupsAddChannelResult()
 
-    def sync(self):
+    def sync(self) -> PNChannelGroupsAddChannelResultEnvelope:
         return PNChannelGroupsAddChannelResultEnvelope(super().sync())
 
     def request_timeout(self):

--- a/pubnub/endpoints/channel_groups/list_channels_in_channel_group.py
+++ b/pubnub/endpoints/channel_groups/list_channels_in_channel_group.py
@@ -4,19 +4,25 @@ from pubnub.errors import PNERR_GROUP_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.models.consumer.channel_group import PNChannelGroupsListResult
+from pubnub.models.consumer.common import PNStatus
+from pubnub.structures import Envelope
+
+
+class PNChannelGroupsListResultEnvelope(Envelope):
+    result: PNChannelGroupsListResult
+    status: PNStatus
 
 
 class ListChannelsInChannelGroup(Endpoint):
     # /v1/channel-registration/sub-key/<sub_key>/channel-group/<group_name>
     LIST_PATH = "/v1/channel-registration/sub-key/%s/channel-group/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel_group: str = None):
         Endpoint.__init__(self, pubnub)
-        self._channel_group = None
-
-    def channel_group(self, channel_group):
         self._channel_group = channel_group
 
+    def channel_group(self, channel_group: str) -> 'ListChannelsInChannelGroup':
+        self._channel_group = channel_group
         return self
 
     def custom_params(self):
@@ -35,11 +41,14 @@ class ListChannelsInChannelGroup(Endpoint):
         if not isinstance(self._channel_group, str) or len(self._channel_group) == 0:
             raise PubNubException(pn_error=PNERR_GROUP_MISSING)
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNChannelGroupsListResult:
         if 'payload' in envelope and 'channels' in envelope['payload']:
             return PNChannelGroupsListResult(envelope['payload']['channels'])
         else:
             return PNChannelGroupsListResult([])
+
+    def sync(self) -> PNChannelGroupsListResultEnvelope:
+        return PNChannelGroupsListResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/channel_groups/remove_channel_from_channel_group.py
+++ b/pubnub/endpoints/channel_groups/remove_channel_from_channel_group.py
@@ -1,31 +1,38 @@
+from typing import List, Union
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_CHANNELS_MISSING, PNERR_GROUP_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.models.consumer.channel_group import PNChannelGroupsRemoveChannelResult
+from pubnub.models.consumer.common import PNStatus
+from pubnub.structures import Envelope
+
+
+class PNChannelGroupsRemoveChannelResultEnvelope(Envelope):
+    result: PNChannelGroupsRemoveChannelResult
+    status: PNStatus
 
 
 class RemoveChannelFromChannelGroup(Endpoint):
     # /v1/channel-registration/sub-key/<sub_key>/channel-group/<group_name>?remove=ch1,ch2
     REMOVE_PATH = "/v1/channel-registration/sub-key/%s/channel-group/%s"
+    _channels: list = []
+    _channel_group: str = None
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, channel_group: str = None):
         Endpoint.__init__(self, pubnub)
         self._channels = []
-        self._channel_group = None
-
-    def channels(self, channels):
-        if isinstance(channels, (list, tuple)):
-            self._channels.extend(channels)
-        else:
-            self._channels.extend(utils.split_items(channels))
-
-        return self
-
-    def channel_group(self, channel_group):
+        if channels:
+            utils.extend_list(self._channels, channels)
         self._channel_group = channel_group
 
+    def channels(self, channels) -> 'RemoveChannelFromChannelGroup':
+        utils.extend_list(self._channels, channels)
+        return self
+
+    def channel_group(self, channel_group: str) -> 'RemoveChannelFromChannelGroup':
+        self._channel_group = channel_group
         return self
 
     def custom_params(self):
@@ -50,8 +57,11 @@ class RemoveChannelFromChannelGroup(Endpoint):
     def is_auth_required(self):
         return True
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNChannelGroupsRemoveChannelResult:
         return PNChannelGroupsRemoveChannelResult()
+
+    def sync(self):
+        return PNChannelGroupsRemoveChannelResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/channel_groups/remove_channel_from_channel_group.py
+++ b/pubnub/endpoints/channel_groups/remove_channel_from_channel_group.py
@@ -60,7 +60,7 @@ class RemoveChannelFromChannelGroup(Endpoint):
     def create_response(self, envelope) -> PNChannelGroupsRemoveChannelResult:
         return PNChannelGroupsRemoveChannelResult()
 
-    def sync(self):
+    def sync(self) -> PNChannelGroupsRemoveChannelResultEnvelope:
         return PNChannelGroupsRemoveChannelResultEnvelope(super().sync())
 
     def request_timeout(self):

--- a/pubnub/endpoints/channel_groups/remove_channel_group.py
+++ b/pubnub/endpoints/channel_groups/remove_channel_group.py
@@ -4,19 +4,25 @@ from pubnub.errors import PNERR_GROUP_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.models.consumer.channel_group import PNChannelGroupsRemoveGroupResult
+from pubnub.models.consumer.common import PNStatus
+from pubnub.structures import Envelope
+
+
+class PNChannelGroupsRemoveGroupResultEnvelope(Envelope):
+    result: PNChannelGroupsRemoveGroupResult
+    status: PNStatus
 
 
 class RemoveChannelGroup(Endpoint):
     # /v1/channel-registration/sub-key/<sub_key>/channel-group/<group_name>/remove
     REMOVE_PATH = "/v1/channel-registration/sub-key/%s/channel-group/%s/remove"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel_group: str = None):
         Endpoint.__init__(self, pubnub)
-        self._channel_group = None
-
-    def channel_group(self, channel_group):
         self._channel_group = channel_group
 
+    def channel_group(self, channel_group: str) -> 'RemoveChannelGroup':
+        self._channel_group = channel_group
         return self
 
     def custom_params(self):
@@ -40,6 +46,9 @@ class RemoveChannelGroup(Endpoint):
 
     def create_response(self, envelope):
         return PNChannelGroupsRemoveGroupResult()
+
+    def sync(self) -> PNChannelGroupsRemoveGroupResultEnvelope:
+        return PNChannelGroupsRemoveGroupResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/file_operations/delete_file.py
+++ b/pubnub/endpoints/file_operations/delete_file.py
@@ -1,16 +1,24 @@
 from pubnub.endpoints.file_operations.file_based_endpoint import FileOperationEndpoint
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub import utils
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.file import PNDeleteFileResult
+from pubnub.structures import Envelope
+
+
+class PNDeleteFileResultEnvelope(Envelope):
+    result: PNDeleteFileResult
+    status: PNStatus
 
 
 class DeleteFile(FileOperationEndpoint):
     DELETE_FILE_URL = "/v1/files/%s/channels/%s/files/%s/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, file_name: str = None, file_id: str = None):
         FileOperationEndpoint.__init__(self, pubnub)
-        self._file_id = None
-        self._file_name = None
+        self._channel = channel
+        self._file_name = file_name
+        self._file_id = file_id
 
     def build_path(self):
         return DeleteFile.DELETE_FILE_URL % (
@@ -20,11 +28,15 @@ class DeleteFile(FileOperationEndpoint):
             self._file_name
         )
 
-    def file_id(self, file_id):
+    def channel(self, channel) -> 'DeleteFile':
+        self._channel = channel
+        return self
+
+    def file_id(self, file_id) -> 'DeleteFile':
         self._file_id = file_id
         return self
 
-    def file_name(self, file_name):
+    def file_name(self, file_name) -> 'DeleteFile':
         self._file_name = file_name
         return self
 
@@ -45,6 +57,9 @@ class DeleteFile(FileOperationEndpoint):
 
     def create_response(self, envelope):
         return PNDeleteFileResult(envelope)
+
+    def sync(self) -> PNDeleteFileResultEnvelope:
+        return PNDeleteFileResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNDeleteFileOperation

--- a/pubnub/endpoints/file_operations/get_file_url.py
+++ b/pubnub/endpoints/file_operations/get_file_url.py
@@ -1,14 +1,22 @@
 from pubnub.endpoints.file_operations.file_based_endpoint import FileOperationEndpoint
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub import utils
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.file import PNGetFileDownloadURLResult
+from pubnub.structures import Envelope
+
+
+class PNGetFileDownloadURLResultEnvelope(Envelope):
+    result: PNGetFileDownloadURLResult
+    status: PNStatus
 
 
 class GetFileDownloadUrl(FileOperationEndpoint):
     GET_FILE_DOWNLOAD_URL = "/v1/files/%s/channels/%s/files/%s/%s"
 
-    def __init__(self, pubnub, file_name=None, file_id=None):
+    def __init__(self, pubnub, channel: str = None, file_name: str = None, file_id: str = None):
         FileOperationEndpoint.__init__(self, pubnub)
+        self._channel = channel
         self._file_id = file_id
         self._file_name = file_name
 
@@ -27,11 +35,15 @@ class GetFileDownloadUrl(FileOperationEndpoint):
 
         return self.pubnub.config.scheme_extended() + self.pubnub.base_origin + self.build_path() + query_params
 
-    def file_id(self, file_id):
+    def channel(self, channel) -> 'GetFileDownloadUrl':
+        self._channel = channel
+        return self
+
+    def file_id(self, file_id) -> 'GetFileDownloadUrl':
         self._file_id = file_id
         return self
 
-    def file_name(self, file_name):
+    def file_name(self, file_name) -> 'GetFileDownloadUrl':
         self._file_name = file_name
         return self
 
@@ -55,6 +67,9 @@ class GetFileDownloadUrl(FileOperationEndpoint):
 
     def create_response(self, envelope, data=None):
         return PNGetFileDownloadURLResult(envelope)
+
+    def sync(self) -> PNGetFileDownloadURLResultEnvelope:
+        return PNGetFileDownloadURLResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNGetFileDownloadURLAction

--- a/pubnub/endpoints/file_operations/list_files.py
+++ b/pubnub/endpoints/file_operations/list_files.py
@@ -1,20 +1,33 @@
 from pubnub.endpoints.file_operations.file_based_endpoint import FileOperationEndpoint
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub import utils
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.file import PNGetFilesResult
+from pubnub.structures import Envelope
+
+
+class PNGetFilesResultEnvelope(Envelope):
+    result: PNGetFilesResult
+    status: PNStatus
 
 
 class ListFiles(FileOperationEndpoint):
     LIST_FILES_URL = "/v1/files/%s/channels/%s/files"
+    _channel: str
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None):
         FileOperationEndpoint.__init__(self, pubnub)
+        self._channel = channel
 
     def build_path(self):
         return ListFiles.LIST_FILES_URL % (
             self.pubnub.config.subscribe_key,
             utils.url_encode(self._channel)
         )
+
+    def channel(self, channel) -> 'ListFiles':
+        self._channel = channel
+        return self
 
     def http_method(self):
         return HttpMethod.GET
@@ -29,8 +42,11 @@ class ListFiles(FileOperationEndpoint):
         self.validate_subscribe_key()
         self.validate_channel()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetFilesResult:
         return PNGetFilesResult(envelope)
+
+    def sync(self) -> PNGetFilesResultEnvelope:
+        return PNGetFilesResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNGetFilesAction

--- a/pubnub/endpoints/history_delete.py
+++ b/pubnub/endpoints/history_delete.py
@@ -1,26 +1,28 @@
+from typing import Optional
 from pubnub import utils
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.endpoints.endpoint import Endpoint
+from pubnub.structures import Envelope
 
 
 class HistoryDelete(Endpoint):  # pylint: disable=W0612
     HISTORY_DELETE_PATH = "/v3/history/sub-key/%s/channel/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, start: Optional[int] = None, end: Optional[int] = None):
         Endpoint.__init__(self, pubnub)
-        self._channel = None
-        self._start = None
-        self._end = None
+        self._channel = channel
+        self._start = start
+        self._end = end
 
-    def channel(self, channel):
+    def channel(self, channel) -> 'HistoryDelete':
         self._channel = channel
         return self
 
-    def start(self, start):
+    def start(self, start) -> 'HistoryDelete':
         self._start = start
         return self
 
-    def end(self, end):
+    def end(self, end) -> 'HistoryDelete':
         self._end = end
         return self
 
@@ -53,6 +55,9 @@ class HistoryDelete(Endpoint):  # pylint: disable=W0612
 
     def create_response(self, endpoint):
         return {}
+
+    def sync(self) -> Envelope:
+        return super().sync()
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/message_actions/add_message_action.py
+++ b/pubnub/endpoints/message_actions/add_message_action.py
@@ -4,22 +4,29 @@ from pubnub.errors import PNERR_MESSAGE_ACTION_VALUE_MISSING, PNERR_MESSAGE_ACTI
     PNERR_MESSAGE_TIMETOKEN_MISSING, PNERR_MESSAGE_ACTION_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType
-from pubnub.models.consumer.message_actions import PNAddMessageActionResult
+from pubnub.models.consumer.common import PNStatus
+from pubnub.models.consumer.message_actions import PNAddMessageActionResult, PNMessageAction
+from pubnub.structures import Envelope
+
+
+class PNAddMessageActionResultEnvelope(Envelope):
+    result: PNAddMessageActionResult
+    status: PNStatus
 
 
 class AddMessageAction(Endpoint):
     ADD_MESSAGE_ACTION_PATH = "/v1/message-actions/%s/channel/%s/message/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, message_action: PNMessageAction = None):
         Endpoint.__init__(self, pubnub)
-        self._channel = None
-        self._message_action = None
+        self._channel = channel
+        self._message_action = message_action
 
-    def channel(self, channel):
+    def channel(self, channel: str) -> 'AddMessageAction':
         self._channel = str(channel)
         return self
 
-    def message_action(self, message_action):
+    def message_action(self, message_action: PNMessageAction) -> 'AddMessageAction':
         self._message_action = message_action
         return self
 
@@ -51,6 +58,9 @@ class AddMessageAction(Endpoint):
 
     def create_response(self, envelope):  # pylint: disable=W0221
         return PNAddMessageActionResult(envelope['data'])
+
+    def sync(self) -> PNAddMessageActionResultEnvelope:
+        return PNAddMessageActionResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/message_actions/get_message_actions.py
+++ b/pubnub/endpoints/message_actions/get_message_actions.py
@@ -1,35 +1,42 @@
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.message_actions import PNGetMessageActionsResult, PNMessageAction
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.structures import Envelope
+
+
+class PNGetMessageActionsResultEnvelope(Envelope):
+    result: PNGetMessageActionsResult
+    status: PNStatus
 
 
 class GetMessageActions(Endpoint):
     GET_MESSAGE_ACTIONS_PATH = '/v1/message-actions/%s/channel/%s'
     MAX_LIMIT = 100
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, start: str = None, end: str = None, limit: str = None):
         Endpoint.__init__(self, pubnub)
-        self._channel = None
-        self._start = None
-        self._end = None
-        self._limit = GetMessageActions.MAX_LIMIT
+        self._channel = channel
+        self._start = start
+        self._end = end
+        self._limit = limit or GetMessageActions.MAX_LIMIT
 
-    def channel(self, channel):
+    def channel(self, channel: str) -> 'GetMessageActions':
         self._channel = str(channel)
         return self
 
-    def start(self, start):
+    def start(self, start: str) -> 'GetMessageActions':
         assert isinstance(start, str)
         self._start = start
         return self
 
-    def end(self, end):
+    def end(self, end: str) -> 'GetMessageActions':
         assert isinstance(end, str)
         self._end = end
         return self
 
-    def limit(self, limit):
+    def limit(self, limit: str) -> 'GetMessageActions':
         assert isinstance(limit, str)
         self._limit = limit
         return self
@@ -71,6 +78,9 @@ class GetMessageActions(Endpoint):
             result['actions'].append(PNMessageAction(action))
 
         return PNGetMessageActionsResult(result)
+
+    def sync(self) -> PNGetMessageActionsResultEnvelope:
+        return PNGetMessageActionsResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/message_actions/remove_message_action.py
+++ b/pubnub/endpoints/message_actions/remove_message_action.py
@@ -8,21 +8,21 @@ from pubnub.enums import HttpMethod, PNOperationType
 class RemoveMessageAction(Endpoint):
     REMOVE_MESSAGE_ACTION_PATH = "/v1/message-actions/%s/channel/%s/message/%s/action/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, message_timetoken: int = None, action_timetoken: int = None):
         Endpoint.__init__(self, pubnub)
-        self._channel = None
-        self._message_timetoken = None
-        self._action_timetoken = None
+        self._channel = channel
+        self._message_timetoken = message_timetoken
+        self._action_timetoken = action_timetoken
 
-    def channel(self, channel):
+    def channel(self, channel: str) -> 'RemoveMessageAction':
         self._channel = str(channel)
         return self
 
-    def message_timetoken(self, message_timetoken):
+    def message_timetoken(self, message_timetoken: int) -> 'RemoveMessageAction':
         self._message_timetoken = message_timetoken
         return self
 
-    def action_timetoken(self, action_timetoken):
+    def action_timetoken(self, action_timetoken: int) -> 'RemoveMessageAction':
         self._action_timetoken = action_timetoken
         return self
 

--- a/pubnub/endpoints/objects_v2/channel/get_all_channels.py
+++ b/pubnub/endpoints/objects_v2/channel/get_all_channels.py
@@ -2,23 +2,36 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, ListEn
     IncludeCustomEndpoint, IncludeStatusTypeEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.channel import PNGetAllChannelMetadataResult
+from pubnub.models.consumer.objects_v2.page import PNPage
+from pubnub.structures import Envelope
+
+
+class PNGetAllChannelMetadataResultEnvelope(Envelope):
+    result: PNGetAllChannelMetadataResult
+    status: PNStatus
 
 
 class GetAllChannels(ObjectsEndpoint, ListEndpoint, IncludeCustomEndpoint, IncludeStatusTypeEndpoint):
     GET_ALL_CHANNELS_PATH = "/v2/objects/%s/channels"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, include_custom=False, include_status=True, include_type=True, limit: int = None,
+                 filter: str = None, include_total_count: bool = None, sort_keys: list = None, page: PNPage = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        ListEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
-        IncludeStatusTypeEndpoint.__init__(self)
+        ListEndpoint.__init__(self, limit=limit, filter=filter, include_total_count=include_total_count,
+                              sort_keys=sort_keys, page=page)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
+        IncludeStatusTypeEndpoint.__init__(self, include_status=include_status, include_type=include_type)
 
     def build_path(self):
         return GetAllChannels.GET_ALL_CHANNELS_PATH % self.pubnub.config.subscribe_key
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetAllChannelMetadataResult:
         return PNGetAllChannelMetadataResult(envelope)
+
+    def sync(self) -> PNGetAllChannelMetadataResultEnvelope:
+        return PNGetAllChannelMetadataResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNGetAllChannelMetadataOperation

--- a/pubnub/endpoints/objects_v2/channel/get_channel.py
+++ b/pubnub/endpoints/objects_v2/channel/get_channel.py
@@ -2,17 +2,25 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, Includ
     IncludeStatusTypeEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.channel import PNGetChannelMetadataResult
+from pubnub.structures import Envelope
+
+
+class PNGetChannelMetadataResultEnvelope(Envelope):
+    result: PNGetChannelMetadataResult
+    status: PNStatus
 
 
 class GetChannel(ObjectsEndpoint, ChannelEndpoint, IncludeCustomEndpoint, IncludeStatusTypeEndpoint):
     GET_CHANNEL_PATH = "/v2/objects/%s/channels/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, include_custom: bool = False, include_status: bool = True,
+                 include_type: bool = True):
         ObjectsEndpoint.__init__(self, pubnub)
-        ChannelEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
-        IncludeStatusTypeEndpoint.__init__(self)
+        ChannelEndpoint.__init__(self, channel=channel)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
+        IncludeStatusTypeEndpoint.__init__(self, include_status=include_status, include_type=include_type)
 
     def build_path(self):
         return GetChannel.GET_CHANNEL_PATH % (self.pubnub.config.subscribe_key, self._channel)
@@ -20,8 +28,11 @@ class GetChannel(ObjectsEndpoint, ChannelEndpoint, IncludeCustomEndpoint, Includ
     def validate_specific_params(self):
         self._validate_channel()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetChannelMetadataResult:
         return PNGetChannelMetadataResult(envelope)
+
+    def sync(self) -> PNGetChannelMetadataResultEnvelope:
+        return PNGetChannelMetadataResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNGetChannelMetadataOperation

--- a/pubnub/endpoints/objects_v2/channel/remove_channel.py
+++ b/pubnub/endpoints/objects_v2/channel/remove_channel.py
@@ -1,15 +1,22 @@
 from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, ChannelEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.channel import PNRemoveChannelMetadataResult
+from pubnub.structures import Envelope
+
+
+class PNRemoveChannelMetadataResultEnvelope(Envelope):
+    result: PNRemoveChannelMetadataResult
+    status: PNStatus
 
 
 class RemoveChannel(ObjectsEndpoint, ChannelEndpoint):
     REMOVE_CHANNEL_PATH = "/v2/objects/%s/channels/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        ChannelEndpoint.__init__(self)
+        ChannelEndpoint.__init__(self, channel=channel)
 
     def build_path(self):
         return RemoveChannel.REMOVE_CHANNEL_PATH % (self.pubnub.config.subscribe_key, self._channel)
@@ -17,8 +24,11 @@ class RemoveChannel(ObjectsEndpoint, ChannelEndpoint):
     def validate_specific_params(self):
         self._validate_channel()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNRemoveChannelMetadataResult:
         return PNRemoveChannelMetadataResult(envelope)
+
+    def sync(self) -> PNRemoveChannelMetadataResultEnvelope:
+        return PNRemoveChannelMetadataResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNRemoveChannelMetadataOperation

--- a/pubnub/endpoints/objects_v2/channel/set_channel.py
+++ b/pubnub/endpoints/objects_v2/channel/set_channel.py
@@ -3,38 +3,46 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, Includ
     ChannelEndpoint, CustomAwareEndpoint, IncludeStatusTypeEndpoint, StatusTypeAwareEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.channel import PNSetChannelMetadataResult
+from pubnub.structures import Envelope
+
+
+class PNSetChannelMetadataResultEnvelope(Envelope):
+    result: PNSetChannelMetadataResult
+    status: PNStatus
 
 
 class SetChannel(ObjectsEndpoint, ChannelEndpoint, IncludeCustomEndpoint, CustomAwareEndpoint,
                  IncludeStatusTypeEndpoint, StatusTypeAwareEndpoint):
     SET_CHANNEL_PATH = "/v2/objects/%s/channels/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, custom: dict = None, include_custom: bool = False,
+                 include_status: bool = True, include_type: bool = True, name: str = None, description: str = None,
+                 status: str = None, type: str = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        ChannelEndpoint.__init__(self)
-        CustomAwareEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
-        IncludeStatusTypeEndpoint.__init__(self)
+        ChannelEndpoint.__init__(self, channel=channel)
+        CustomAwareEndpoint.__init__(self, custom=custom)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
+        IncludeStatusTypeEndpoint.__init__(self, include_status=include_status, include_type=include_type)
+        self._name = name
+        self._description = description
+        self._status = status
+        self._type = type
 
-        self._name = None
-        self._description = None
-        self._status = None
-        self._type = None
-
-    def set_name(self, name):
+    def set_name(self, name: str) -> 'SetChannel':
         self._name = str(name)
         return self
 
-    def set_status(self, status: str = None):
+    def set_status(self, status: str = None) -> 'SetChannel':
         self._status = status
         return self
 
-    def set_type(self, type: str = None):
+    def set_type(self, type: str = None) -> 'SetChannel':
         self._type = type
         return self
 
-    def description(self, description):
+    def description(self, description) -> 'SetChannel':
         self._description = str(description)
         return self
 
@@ -55,8 +63,11 @@ class SetChannel(ObjectsEndpoint, ChannelEndpoint, IncludeCustomEndpoint, Custom
         payload = StatusTypeAwareEndpoint.build_data(self, payload)
         return utils.write_value_as_string(payload)
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNSetChannelMetadataResult:
         return PNSetChannelMetadataResult(envelope)
+
+    def sync(self) -> PNSetChannelMetadataResultEnvelope:
+        return PNSetChannelMetadataResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNSetChannelMetadataOperation

--- a/pubnub/endpoints/objects_v2/members/get_channel_members.py
+++ b/pubnub/endpoints/objects_v2/members/get_channel_members.py
@@ -2,18 +2,28 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, Includ
     ChannelEndpoint, ListEndpoint, UUIDIncludeEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.channel_members import PNGetChannelMembersResult
+from pubnub.models.consumer.objects_v2.page import PNPage
+from pubnub.structures import Envelope
+
+
+class PNGetChannelMembersResultEnvelope(Envelope):
+    result: PNGetChannelMembersResult
+    status: PNStatus
 
 
 class GetChannelMembers(ObjectsEndpoint, ChannelEndpoint, ListEndpoint, IncludeCustomEndpoint,
                         UUIDIncludeEndpoint):
     GET_CHANNEL_MEMBERS_PATH = "/v2/objects/%s/channels/%s/uuids"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, include_custom: bool = None, limit: int = None, filter: str = None,
+                 include_total_count: bool = None, sort_keys: list = None, page: PNPage = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        ChannelEndpoint.__init__(self)
-        ListEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
+        ChannelEndpoint.__init__(self, channel=channel)
+        ListEndpoint.__init__(self, limit=limit, filter=filter, include_total_count=include_total_count,
+                              sort_keys=sort_keys, page=page)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
         UUIDIncludeEndpoint.__init__(self)
 
     def build_path(self):
@@ -22,8 +32,11 @@ class GetChannelMembers(ObjectsEndpoint, ChannelEndpoint, ListEndpoint, IncludeC
     def validate_specific_params(self):
         self._validate_channel()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetChannelMembersResult:
         return PNGetChannelMembersResult(envelope)
+
+    def sync(self) -> PNGetChannelMembersResultEnvelope:
+        return PNGetChannelMembersResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNGetChannelMembersOperation

--- a/pubnub/endpoints/objects_v2/members/set_channel_members.py
+++ b/pubnub/endpoints/objects_v2/members/set_channel_members.py
@@ -1,26 +1,40 @@
+from typing import List
 from pubnub import utils
 from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, IncludeCustomEndpoint, \
     UUIDIncludeEndpoint, ChannelEndpoint, ListEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.channel_members import PNSetChannelMembersResult
+from pubnub.models.consumer.objects_v2.page import PNPage
+from pubnub.structures import Envelope
+
+
+class PNSetChannelMembersResultEnvelope(Envelope):
+    result: PNSetChannelMembersResult
+    status: PNStatus
 
 
 class SetChannelMembers(ObjectsEndpoint, ChannelEndpoint, ListEndpoint, IncludeCustomEndpoint,
                         UUIDIncludeEndpoint):
     SET_CHANNEL_MEMBERS_PATH = "/v2/objects/%s/channels/%s/uuids"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channel: str = None, uuids: List[str] = None, include_custom: bool = None,
+                 limit: int = None, filter: str = None, include_total_count: bool = None, sort_keys: list = None,
+                 page: PNPage = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        ListEndpoint.__init__(self)
-        ChannelEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
+        ListEndpoint.__init__(self, limit=limit, filter=filter, include_total_count=include_total_count,
+                              sort_keys=sort_keys, page=page)
+        ChannelEndpoint.__init__(self, channel=channel)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
         UUIDIncludeEndpoint.__init__(self)
 
         self._uuids = []
+        if self._uuids:
+            utils.extend_list(self._uuids, uuids)
 
-    def uuids(self, uuids):
-        self._uuids = list(uuids)
+    def uuids(self, uuids) -> 'SetChannelMembers':
+        utils.extend_list(self._uuids, uuids)
         return self
 
     def validate_specific_params(self):
@@ -41,8 +55,11 @@ class SetChannelMembers(ObjectsEndpoint, ChannelEndpoint, ListEndpoint, IncludeC
         }
         return utils.write_value_as_string(payload)
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNSetChannelMembersResult:
         return PNSetChannelMembersResult(envelope)
+
+    def sync(self) -> PNSetChannelMembersResultEnvelope:
+        return PNSetChannelMembersResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNSetChannelMembersOperation

--- a/pubnub/endpoints/objects_v2/memberships/get_memberships.py
+++ b/pubnub/endpoints/objects_v2/memberships/get_memberships.py
@@ -2,18 +2,28 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, Includ
     UuidEndpoint, ListEndpoint, ChannelIncludeEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.memberships import PNGetMembershipsResult
+from pubnub.models.consumer.objects_v2.page import PNPage
+from pubnub.structures import Envelope
+
+
+class PNGetMembershipsResultEnvelope(Envelope):
+    result: PNGetMembershipsResult
+    status: PNStatus
 
 
 class GetMemberships(ObjectsEndpoint, UuidEndpoint, ListEndpoint, IncludeCustomEndpoint,
                      ChannelIncludeEndpoint):
     GET_MEMBERSHIPS_PATH = "/v2/objects/%s/uuids/%s/channels"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, uuid: str = None, include_custom: bool = False, limit: int = None, filter: str = None,
+                 include_total_count: bool = None, sort_keys: list = None, page: PNPage = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        UuidEndpoint.__init__(self)
-        ListEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
+        UuidEndpoint.__init__(self, uuid=uuid)
+        ListEndpoint.__init__(self, limit=limit, filter=filter, include_total_count=include_total_count,
+                              sort_keys=sort_keys, page=page)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
         ChannelIncludeEndpoint.__init__(self)
 
     def build_path(self):
@@ -22,8 +32,11 @@ class GetMemberships(ObjectsEndpoint, UuidEndpoint, ListEndpoint, IncludeCustomE
     def validate_specific_params(self):
         self._validate_uuid()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetMembershipsResult:
         return PNGetMembershipsResult(envelope)
+
+    def sync(self):
+        return super().sync()
 
     def operation_type(self):
         return PNOperationType.PNGetMembershipsOperation

--- a/pubnub/endpoints/objects_v2/memberships/get_memberships.py
+++ b/pubnub/endpoints/objects_v2/memberships/get_memberships.py
@@ -35,8 +35,8 @@ class GetMemberships(ObjectsEndpoint, UuidEndpoint, ListEndpoint, IncludeCustomE
     def create_response(self, envelope) -> PNGetMembershipsResult:
         return PNGetMembershipsResult(envelope)
 
-    def sync(self):
-        return super().sync()
+    def sync(self) -> PNGetMembershipsResultEnvelope:
+        return PNGetMembershipsResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNGetMembershipsOperation

--- a/pubnub/endpoints/objects_v2/objects_endpoint.py
+++ b/pubnub/endpoints/objects_v2/objects_endpoint.py
@@ -5,7 +5,7 @@ from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_UUID_MISSING, PNERR_CHANNEL_MISSING
 from pubnub.exceptions import PubNubException
-from pubnub.models.consumer.objects_v2.page import Next, Previous
+from pubnub.models.consumer.objects_v2.page import Next, PNPage, Previous
 
 logger = logging.getLogger("pubnub")
 
@@ -101,10 +101,10 @@ class ObjectsEndpoint(Endpoint):
 class CustomAwareEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
+    def __init__(self, custom: dict = None):
         self._custom = None
 
-    def custom(self, custom):
+    def custom(self, custom: dict):
         self._custom = dict(custom)
         self._include_custom = True
         return self
@@ -113,15 +113,15 @@ class CustomAwareEndpoint:
 class StatusTypeAwareEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
-        self._status = None
-        self._type = None
+    def __init__(self, status: str = None, type: str = None):
+        self._status = status
+        self._type = type
 
     def set_status(self, status: str):
         self._status = status
         return self
 
-    def set_type(self, type):
+    def set_type(self, type: str):
         self._type = type
         return self
 
@@ -136,10 +136,10 @@ class StatusTypeAwareEndpoint:
 class ChannelEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
-        self._channel = None
+    def __init__(self, channel: str = None):
+        self._channel = channel
 
-    def channel(self, channel):
+    def channel(self, channel: str):
         self._channel = str(channel)
         return self
 
@@ -151,10 +151,10 @@ class ChannelEndpoint:
 class UuidEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
-        self._uuid = None
+    def __init__(self, uuid: str = None):
+        self._uuid = uuid
 
-    def uuid(self, uuid):
+    def uuid(self, uuid: str):
         self._uuid = str(uuid)
         return self
 
@@ -172,30 +172,31 @@ class UuidEndpoint:
 class ListEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
-        self._limit = None
-        self._filter = None
-        self._include_total_count = None
-        self._sort_keys = None
-        self._page = None
+    def __init__(self, limit: int = None, filter: str = None, include_total_count: bool = None, sort_keys: list = None,
+                 page: PNPage = None):
+        self._limit = limit
+        self._filter = filter
+        self._include_total_count = include_total_count
+        self._sort_keys = sort_keys
+        self._page = page
 
-    def limit(self, limit):
+    def limit(self, limit: int):
         self._limit = int(limit)
         return self
 
-    def filter(self, filter):
+    def filter(self, filter: str):
         self._filter = str(filter)
         return self
 
-    def include_total_count(self, include_total_count):
+    def include_total_count(self, include_total_count: bool):
         self._include_total_count = bool(include_total_count)
         return self
 
-    def sort(self, *sort_keys):
+    def sort(self, *sort_keys: list):
         self._sort_keys = sort_keys
         return self
 
-    def page(self, page):
+    def page(self, page: PNPage):
         self._page = page
         return self
 
@@ -203,10 +204,10 @@ class ListEndpoint:
 class IncludeCustomEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
-        self._include_custom = None
+    def __init__(self, include_custom: bool = None):
+        self._include_custom = include_custom
 
-    def include_custom(self, include_custom):
+    def include_custom(self, include_custom: bool):
         self._include_custom = bool(include_custom)
         return self
 
@@ -214,15 +215,15 @@ class IncludeCustomEndpoint:
 class IncludeStatusTypeEndpoint:
     __metaclass__ = ABCMeta
 
-    def __init__(self):
-        self._include_status = True
-        self._include_type = True
+    def __init__(self, include_status: bool = None, include_type: bool = None):
+        self._include_status = include_status
+        self._include_type = include_type
 
-    def include_status(self, include_status):
+    def include_status(self, include_status: bool):
         self._include_status = bool(include_status)
         return self
 
-    def include_type(self, include_type):
+    def include_type(self, include_type: bool):
         self._include_type = bool(include_type)
         return self
 

--- a/pubnub/endpoints/objects_v2/uuid/get_all_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/get_all_uuid.py
@@ -8,11 +8,13 @@ from pubnub.models.consumer.objects_v2.uuid import PNGetAllUUIDMetadataResult
 class GetAllUuid(ObjectsEndpoint, ListEndpoint, IncludeCustomEndpoint, IncludeStatusTypeEndpoint):
     GET_ALL_UID_PATH = "/v2/objects/%s/uuids"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, include_custom: bool = None, include_status: bool = True, include_type: bool = True,
+                 limit: int = None, filter: str = None, include_total_count: bool = None, sort_keys: list = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        ListEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
-        IncludeStatusTypeEndpoint.__init__(self)
+        ListEndpoint.__init__(self, limit=limit, filter=filter, include_total_count=include_total_count,
+                              sort_keys=sort_keys)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
+        IncludeStatusTypeEndpoint.__init__(self, include_status=include_status, include_type=include_type)
 
     def build_path(self):
         return GetAllUuid.GET_ALL_UID_PATH % self.pubnub.config.subscribe_key

--- a/pubnub/endpoints/objects_v2/uuid/get_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/get_uuid.py
@@ -31,6 +31,9 @@ class GetUuid(ObjectsEndpoint, UuidEndpoint, IncludeCustomEndpoint, IncludeStatu
     def create_response(self, envelope) -> PNGetUUIDMetadataResult:
         return PNGetUUIDMetadataResult(envelope)
 
+    def sync(self) -> PNGetUUIDMetadataResultEnvelope:
+        return PNGetUUIDMetadataResultEnvelope(super().sync())
+
     def operation_type(self):
         return PNOperationType.PNGetUuidMetadataOperation
 

--- a/pubnub/endpoints/objects_v2/uuid/get_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/get_uuid.py
@@ -2,17 +2,25 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, \
     IncludeCustomEndpoint, UuidEndpoint, IncludeStatusTypeEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.uuid import PNGetUUIDMetadataResult
+from pubnub.structures import Envelope
+
+
+class PNGetUUIDMetadataResultEnvelope(Envelope):
+    result: PNGetUUIDMetadataResult
+    status: PNStatus
 
 
 class GetUuid(ObjectsEndpoint, UuidEndpoint, IncludeCustomEndpoint, IncludeStatusTypeEndpoint):
     GET_UID_PATH = "/v2/objects/%s/uuids/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, uuid: str = None, include_custom: bool = None, include_status: bool = True,
+                 include_type: bool = True):
         ObjectsEndpoint.__init__(self, pubnub)
-        UuidEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
-        IncludeStatusTypeEndpoint.__init__(self)
+        UuidEndpoint.__init__(self, uuid=uuid)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
+        IncludeStatusTypeEndpoint.__init__(self, include_status=include_status, include_type=include_type)
 
     def build_path(self):
         return GetUuid.GET_UID_PATH % (self.pubnub.config.subscribe_key, self._effective_uuid())
@@ -20,7 +28,7 @@ class GetUuid(ObjectsEndpoint, UuidEndpoint, IncludeCustomEndpoint, IncludeStatu
     def validate_specific_params(self):
         self._validate_uuid()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetUUIDMetadataResult:
         return PNGetUUIDMetadataResult(envelope)
 
     def operation_type(self):

--- a/pubnub/endpoints/objects_v2/uuid/remove_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/remove_uuid.py
@@ -27,7 +27,7 @@ class RemoveUuid(ObjectsEndpoint, UuidEndpoint):
     def create_response(self, envelope) -> PNRemoveUUIDMetadataResult:
         return PNRemoveUUIDMetadataResult(envelope)
 
-    def sync(self):
+    def sync(self) -> PNRemoveUUIDMetadataResultEnvelope:
         return PNRemoveUUIDMetadataResultEnvelope(super().sync())
 
     def operation_type(self):

--- a/pubnub/endpoints/objects_v2/uuid/remove_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/remove_uuid.py
@@ -1,15 +1,22 @@
 from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, UuidEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.uuid import PNRemoveUUIDMetadataResult
+from pubnub.structures import Envelope
+
+
+class PNRemoveUUIDMetadataResultEnvelope(Envelope):
+    result: PNRemoveUUIDMetadataResult
+    status: PNStatus
 
 
 class RemoveUuid(ObjectsEndpoint, UuidEndpoint):
     REMOVE_UID_PATH = "/v2/objects/%s/uuids/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, uuid: str = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        UuidEndpoint.__init__(self)
+        UuidEndpoint.__init__(self, uuid=uuid)
 
     def build_path(self):
         return RemoveUuid.REMOVE_UID_PATH % (self.pubnub.config.subscribe_key, self._effective_uuid())
@@ -17,8 +24,11 @@ class RemoveUuid(ObjectsEndpoint, UuidEndpoint):
     def validate_specific_params(self):
         self._validate_uuid()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNRemoveUUIDMetadataResult:
         return PNRemoveUUIDMetadataResult(envelope)
+
+    def sync(self):
+        return PNRemoveUUIDMetadataResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNRemoveUuidMetadataOperation

--- a/pubnub/endpoints/objects_v2/uuid/set_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/set_uuid.py
@@ -68,7 +68,7 @@ class SetUuid(ObjectsEndpoint, UuidEndpoint, IncludeCustomEndpoint, CustomAwareE
     def create_response(self, envelope) -> PNSetUUIDMetadataResult:
         return PNSetUUIDMetadataResult(envelope)
 
-    def sync(self):
+    def sync(self) -> PNSetUUIDMetadataResultEnvelope:
         return PNSetUUIDMetadataResultEnvelope(super().sync())
 
     def operation_type(self):

--- a/pubnub/endpoints/objects_v2/uuid/set_uuid.py
+++ b/pubnub/endpoints/objects_v2/uuid/set_uuid.py
@@ -3,39 +3,48 @@ from pubnub.endpoints.objects_v2.objects_endpoint import ObjectsEndpoint, UuidEn
     IncludeCustomEndpoint, CustomAwareEndpoint, IncludeStatusTypeEndpoint, StatusTypeAwareEndpoint
 from pubnub.enums import PNOperationType
 from pubnub.enums import HttpMethod
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.objects_v2.uuid import PNSetUUIDMetadataResult
+from pubnub.structures import Envelope
+
+
+class PNSetUUIDMetadataResultEnvelope(Envelope):
+    result: PNSetUUIDMetadataResult
+    status: PNStatus
 
 
 class SetUuid(ObjectsEndpoint, UuidEndpoint, IncludeCustomEndpoint, CustomAwareEndpoint, IncludeStatusTypeEndpoint,
               StatusTypeAwareEndpoint):
     SET_UID_PATH = "/v2/objects/%s/uuids/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, uuid: str = None, include_custom: bool = None, custom: dict = None,
+                 include_status: bool = True, include_type: bool = True, status: str = None, type: str = None,
+                 name: str = None, email: str = None, external_id: str = None, profile_url: str = None):
         ObjectsEndpoint.__init__(self, pubnub)
-        UuidEndpoint.__init__(self)
-        IncludeCustomEndpoint.__init__(self)
-        CustomAwareEndpoint.__init__(self)
-        IncludeStatusTypeEndpoint.__init__(self)
-        StatusTypeAwareEndpoint.__init__(self)
+        UuidEndpoint.__init__(self, uuid=uuid)
+        IncludeCustomEndpoint.__init__(self, include_custom=include_custom)
+        CustomAwareEndpoint.__init__(self, custom=custom)
+        IncludeStatusTypeEndpoint.__init__(self, include_status=include_status, include_type=include_type)
+        StatusTypeAwareEndpoint.__init__(self, status=status, type=type)
 
-        self._name = None
-        self._email = None
-        self._external_id = None
-        self._profile_url = None
+        self._name = name
+        self._email = email
+        self._external_id = external_id
+        self._profile_url = profile_url
 
-    def set_name(self, name):
+    def set_name(self, name: str):
         self._name = str(name)
         return self
 
-    def email(self, email):
+    def email(self, email: str):
         self._email = str(email)
         return self
 
-    def external_id(self, external_id):
+    def external_id(self, external_id: str):
         self._external_id = str(external_id)
         return self
 
-    def profile_url(self, profile_url):
+    def profile_url(self, profile_url: str):
         self._profile_url = str(profile_url)
         return self
 
@@ -56,8 +65,11 @@ class SetUuid(ObjectsEndpoint, UuidEndpoint, IncludeCustomEndpoint, CustomAwareE
     def validate_specific_params(self):
         self._validate_uuid()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNSetUUIDMetadataResult:
         return PNSetUUIDMetadataResult(envelope)
+
+    def sync(self):
+        return PNSetUUIDMetadataResultEnvelope(super().sync())
 
     def operation_type(self):
         return PNOperationType.PNSetUuidMetadataOperation

--- a/pubnub/endpoints/presence/get_state.py
+++ b/pubnub/endpoints/presence/get_state.py
@@ -1,29 +1,46 @@
+from typing import List, Union
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.presence import PNGetStateResult
 from pubnub.endpoints.mixins import UUIDValidatorMixin
+from pubnub.structures import Envelope
+
+
+class PNGetStateResultEnvelope(Envelope):
+    result: PNGetStateResult
+    status: PNStatus
 
 
 class GetState(Endpoint, UUIDValidatorMixin):
     # /v2/presence/sub-key/<subscribe_key>/channel/<channel>/uuid/<uuid>/data?state=<state>
     GET_STATE_PATH = "/v2/presence/sub-key/%s/channel/%s/uuid/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                 uuid: str = None):
         Endpoint.__init__(self, pubnub)
         self._channels = []
-        self._groups = []
-        self._uuid = self.pubnub.uuid
+        if channels:
+            utils.extend_list(self._channels, channels)
 
-    def channels(self, channels):
+        self._groups = []
+        if channel_groups:
+            utils.extend_list(self._groups, channel_groups)
+
+        self._uuid = self.pubnub.uuid
+        if uuid:
+            self._uuid = uuid
+
+    def channels(self, channels: Union[str, List[str]]) -> 'GetState':
         utils.extend_list(self._channels, channels)
         return self
 
-    def uuid(self, uuid):
+    def uuid(self, uuid: str) -> 'GetState':
         self._uuid = uuid
         return self
 
-    def channel_groups(self, channel_groups):
+    def channel_groups(self, channel_groups: Union[str, List[str]]) -> 'GetState':
         utils.extend_list(self._groups, channel_groups)
         return self
 
@@ -50,13 +67,16 @@ class GetState(Endpoint, UUIDValidatorMixin):
         self.validate_channels_and_groups()
         self.validate_uuid()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNGetStateResult:
         if len(self._channels) == 1 and len(self._groups) == 0:
             channels = {self._channels[0]: envelope['payload']}
         else:
             channels = envelope['payload']['channels']
 
         return PNGetStateResult(channels)
+
+    def sync(self) -> PNGetStateResultEnvelope:
+        return PNGetStateResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/presence/heartbeat.py
+++ b/pubnub/endpoints/presence/heartbeat.py
@@ -1,3 +1,4 @@
+from typing import Dict, Optional, Union, List
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
@@ -9,23 +10,28 @@ class Heartbeat(Endpoint):
     # /v2/presence/sub-key/<subscribe_key>/channel/<channel>/heartbeat?uuid=<uuid>
     HEARTBEAT_PATH = "/v2/presence/sub-key/%s/channel/%s/heartbeat"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                 state: Optional[Dict[str, any]] = None):
         super(Heartbeat, self).__init__(pubnub)
         self._channels = []
         self._groups = []
-        self._state = None
+        if channels:
+            utils.extend_list(self._channels, channels)
 
-    def channels(self, channels):
+        if channel_groups:
+            utils.extend_list(self._groups, channel_groups)
+
+        self._state = state
+
+    def channels(self, channels: Union[str, List[str]]) -> 'Heartbeat':
         utils.extend_list(self._channels, channels)
-
         return self
 
-    def channel_groups(self, channel_groups):
+    def channel_groups(self, channel_groups: Union[str, List[str]]) -> 'Heartbeat':
         utils.extend_list(self._groups, channel_groups)
-
         return self
 
-    def state(self, state):
+    def state(self, state: Dict[str, any]) -> 'Heartbeat':
         self._state = state
 
         return self

--- a/pubnub/endpoints/presence/here_now.py
+++ b/pubnub/endpoints/presence/here_now.py
@@ -1,33 +1,48 @@
+from typing import List, Union
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.presence import PNHereNowResult
+from pubnub.structures import Envelope
+
+
+class PNHereNowResultEnvelope(Envelope):
+    result: PNHereNowResult
+    status: PNStatus
 
 
 class HereNow(Endpoint):
     HERE_NOW_PATH = "/v2/presence/sub-key/%s/channel/%s"
     HERE_NOW_GLOBAL_PATH = "/v2/presence/sub-key/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                 include_state: bool = False, include_uuids: bool = True):
         Endpoint.__init__(self, pubnub)
         self._channels = []
-        self._channel_groups = []
-        self._include_state = False
-        self._include_uuids = True
+        if channels:
+            utils.extend_list(self._channels, channels)
 
-    def channels(self, channels):
+        self._channel_groups = []
+        if channel_groups:
+            utils.extend_list(self._channel_groups, channel_groups)
+
+        self._include_state = include_state
+        self._include_uuids = include_uuids
+
+    def channels(self, channels: Union[str, List[str]]) -> 'HereNow':
         utils.extend_list(self._channels, channels)
         return self
 
-    def channel_groups(self, channel_groups):
+    def channel_groups(self, channel_groups: Union[str, List[str]]) -> 'HereNow':
         utils.extend_list(self._channel_groups, channel_groups)
         return self
 
-    def include_state(self, should_include_state):
+    def include_state(self, should_include_state) -> 'HereNow':
         self._include_state = should_include_state
         return self
 
-    def include_uuids(self, include_uuids):
+    def include_uuids(self, include_uuids) -> 'HereNow':
         self._include_uuids = include_uuids
         return self
 
@@ -61,8 +76,11 @@ class HereNow(Endpoint):
     def is_auth_required(self):
         return True
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNHereNowResult:
         return PNHereNowResult.from_json(envelope, self._channels)
+
+    def sync(self) -> PNHereNowResultEnvelope:
+        return PNHereNowResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/presence/where_now.py
+++ b/pubnub/endpoints/presence/where_now.py
@@ -1,19 +1,29 @@
+from typing import Optional
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.presence import PNWhereNowResult
 from pubnub.endpoints.mixins import UUIDValidatorMixin
+from pubnub.structures import Envelope
+
+
+class PNWhereNowResultEnvelope(Envelope):
+    result: PNWhereNowResult
+    status: PNStatus
 
 
 class WhereNow(Endpoint, UUIDValidatorMixin):
     # /v2/presence/sub-key/<subscribe_key>/uuid/<uuid>
     WHERE_NOW_PATH = "/v2/presence/sub-key/%s/uuid/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, uuid: Optional[str] = None):
         Endpoint.__init__(self, pubnub)
         self._uuid = pubnub.config.uuid
+        if uuid:
+            self._uuid = uuid
 
-    def uuid(self, uuid):
+    def uuid(self, uuid: str) -> 'WhereNow':
         self._uuid = uuid
         return self
 
@@ -35,6 +45,9 @@ class WhereNow(Endpoint, UUIDValidatorMixin):
 
     def create_response(self, envelope):
         return PNWhereNowResult.from_json(envelope)
+
+    def sync(self) -> PNWhereNowResultEnvelope:
+        return PNWhereNowResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/pubsub/fire.py
+++ b/pubnub/endpoints/pubsub/fire.py
@@ -4,7 +4,14 @@ from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.exceptions import PubNubException
 from pubnub.errors import PNERR_MESSAGE_MISSING
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.pubsub import PNFireResult
+from pubnub.structures import Envelope
+
+
+class PNFireResultEnvelope(Envelope):
+    result: PNFireResult
+    status: PNStatus
 
 
 class Fire(Endpoint):
@@ -107,7 +114,7 @@ class Fire(Endpoint):
         self.validate_subscribe_key()
         self.validate_publish_key()
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNFireResult:
         """
         :param envelope: an already serialized json response
         :return:
@@ -120,6 +127,9 @@ class Fire(Endpoint):
         res = PNFireResult(envelope, timetoken)
 
         return res
+
+    def sync(self) -> PNFireResultEnvelope:
+        return PNFireResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/pubsub/fire.py
+++ b/pubnub/endpoints/pubsub/fire.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
@@ -11,33 +12,39 @@ class Fire(Endpoint):
     FIRE_GET_PATH = "/publish/%s/%s/0/%s/%s/%s"
     FIRE_POST_PATH = "/publish/%s/%s/0/%s/%s"
 
-    def __init__(self, pubnub):
-        Endpoint.__init__(self, pubnub)
-        self._channel = None
-        self._message = None
-        self._use_post = None
-        self._meta = None
+    _channel: str
+    _message: any
+    _use_post: Optional[bool]
+    _meta: Optional[any]
 
-    def channel(self, channel):
+    def __init__(self, pubnub, channel: Optional[str] = None, message: Optional[any] = None,
+                 use_post: Optional[bool] = None, meta: Optional[any] = None):
+        Endpoint.__init__(self, pubnub)
+        self._channel = channel
+        self._message = message
+        self._use_post = use_post
+        self._meta = meta
+
+    def channel(self, channel: str) -> 'Fire':
         self._channel = str(channel)
         return self
 
-    def message(self, message):
+    def message(self, message) -> 'Fire':
         self._message = message
         return self
 
-    def use_post(self, use_post):
+    def use_post(self, use_post) -> 'Fire':
         self._use_post = bool(use_post)
         return self
 
-    def is_compressable(self):
+    def is_compressable(self) -> bool:
         return True
 
-    def use_compression(self, compress=True):
+    def use_compression(self, compress=True) -> 'Fire':
         self._use_compression = bool(compress)
         return self
 
-    def meta(self, meta):
+    def meta(self, meta) -> 'Fire':
         self._meta = meta
         return self
 

--- a/pubnub/endpoints/pubsub/publish.py
+++ b/pubnub/endpoints/pubsub/publish.py
@@ -3,9 +3,16 @@ from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_MESSAGE_MISSING
 from pubnub.exceptions import PubNubException
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.pubsub import PNPublishResult
 from pubnub.enums import HttpMethod, PNOperationType
 from pubnub.endpoints.mixins import TimeTokenOverrideMixin
+from pubnub.structures import Envelope
+
+
+class PNPublishResultEnvelope(Envelope):
+    result: PNPublishResult
+    status: PNStatus
 
 
 class Publish(Endpoint, TimeTokenOverrideMixin):
@@ -22,9 +29,10 @@ class Publish(Endpoint, TimeTokenOverrideMixin):
     _ptto: Optional[int]
     _ttl: Optional[int]
 
-    def __init__(self, pubnub, channel: Optional[str] = None, message: Optional[any] = None,
+    def __init__(self, pubnub, channel: str = None, message: any = None,
                  should_store: Optional[bool] = None, use_post: Optional[bool] = None, meta: Optional[any] = None,
                  replicate: Optional[bool] = None, ptto: Optional[int] = None, ttl: Optional[int] = None):
+
         super(Publish, self).__init__(pubnub)
         self._channel = channel
         self._message = message
@@ -157,6 +165,9 @@ class Publish(Endpoint, TimeTokenOverrideMixin):
         res = PNPublishResult(envelope, timetoken)
 
         return res
+
+    def sync(self) -> PNPublishResultEnvelope:
+        return PNPublishResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/pubsub/publish.py
+++ b/pubnub/endpoints/pubsub/publish.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_MESSAGE_MISSING
@@ -12,45 +13,56 @@ class Publish(Endpoint, TimeTokenOverrideMixin):
     PUBLISH_GET_PATH = "/publish/%s/%s/0/%s/%s/%s"
     PUBLISH_POST_PATH = "/publish/%s/%s/0/%s/%s"
 
-    def __init__(self, pubnub):
-        super(Publish, self).__init__(pubnub)
-        self._channel = None
-        self._message = None
-        self._should_store = None
-        self._use_post = None
-        self._meta = None
-        self._replicate = None
-        self._ptto = None
-        self._ttl = None
+    _channel: str
+    _message: any
+    _should_store: Optional[bool]
+    _use_post: Optional[bool]
+    _meta: Optional[any]
+    _replicate: Optional[bool]
+    _ptto: Optional[int]
+    _ttl: Optional[int]
 
-    def channel(self, channel):
+    def __init__(self, pubnub, channel: Optional[str] = None, message: Optional[any] = None,
+                 should_store: Optional[bool] = None, use_post: Optional[bool] = None, meta: Optional[any] = None,
+                 replicate: Optional[bool] = None, ptto: Optional[int] = None, ttl: Optional[int] = None):
+        super(Publish, self).__init__(pubnub)
+        self._channel = channel
+        self._message = message
+        self._should_store = should_store
+        self._use_post = use_post
+        self._meta = meta
+        self._replicate = replicate
+        self._ptto = ptto
+        self._ttl = ttl
+
+    def channel(self, channel: str) -> 'Publish':
         self._channel = str(channel)
         return self
 
-    def message(self, message):
+    def message(self, message: any) -> 'Publish':
         self._message = message
         return self
 
-    def use_post(self, use_post):
+    def use_post(self, use_post: bool) -> 'Publish':
         self._use_post = bool(use_post)
         return self
 
-    def use_compression(self, compress=True):
+    def use_compression(self, compress: bool = True) -> 'Publish':
         self._use_compression = bool(compress)
         return self
 
-    def is_compressable(self):
+    def is_compressable(self) -> bool:
         return True
 
-    def should_store(self, should_store):
+    def should_store(self, should_store: bool) -> 'Publish':
         self._should_store = bool(should_store)
         return self
 
-    def meta(self, meta):
+    def meta(self, meta: any) -> 'Publish':
         self._meta = meta
         return self
 
-    def ttl(self, ttl):
+    def ttl(self, ttl: int) -> 'Publish':
         self._ttl = ttl
         return self
 

--- a/pubnub/endpoints/pubsub/subscribe.py
+++ b/pubnub/endpoints/pubsub/subscribe.py
@@ -1,3 +1,4 @@
+from typing import Optional, Union, List
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
@@ -9,43 +10,55 @@ class Subscribe(Endpoint):
     # /subscribe/<sub-key>/<channel>/<callback>/<timetoken>
     SUBSCRIBE_PATH = "/v2/subscribe/%s/%s/0"
 
-    def __init__(self, pubnub):
+    _channels: list = []
+    _groups: list = []
+
+    region: Optional[str] = None
+    filter_expression: Optional[str] = None
+    timetoken: Optional[str] = None
+    with_presence: Optional[str] = None
+    state: Optional[str] = None
+
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None,
+                 groups: Union[str, List[str]] = None, region: Optional[str] = None,
+                 filter_expression: Optional[str] = None, timetoken: Optional[str] = None,
+                 with_presence: Optional[str] = None, state: Optional[str] = None):
+
         super(Subscribe, self).__init__(pubnub)
         self._channels = []
+        if channels:
+            utils.extend_list(self._channels, channels)
         self._groups = []
+        if groups:
+            utils.extend_list(self._groups, groups)
 
-        self._region = None
-        self._filter_expression = None
-        self._timetoken = None
-        self._with_presence = None
-        self._state = None
-
-    def channels(self, channels):
-        utils.extend_list(self._channels, channels)
-
-        return self
-
-    def channel_groups(self, groups):
-        utils.extend_list(self._groups, groups)
-
-        return self
-
-    def timetoken(self, timetoken):
-        self._timetoken = timetoken
-
-        return self
-
-    def filter_expression(self, expr):
-        self._filter_expression = expr
-
-        return self
-
-    def region(self, region):
         self._region = region
+        self._filter_expression = filter_expression
+        self._timetoken = timetoken
+        self._with_presence = with_presence
+        self._state = state
 
+    def channels(self, channels: Union[str, List[str]]) -> 'Subscribe':
+        utils.extend_list(self._channels, channels)
         return self
 
-    def state(self, state):
+    def channel_groups(self, groups: Union[str, List[str]]) -> 'Subscribe':
+        utils.extend_list(self._groups, groups)
+        return self
+
+    def timetoken(self, timetoken) -> 'Subscribe':
+        self._timetoken = timetoken
+        return self
+
+    def filter_expression(self, expr) -> 'Subscribe':
+        self._filter_expression = expr
+        return self
+
+    def region(self, region) -> 'Subscribe':
+        self._region = region
+        return self
+
+    def state(self, state) -> 'Subscribe':
         self._state = state
         return self
 

--- a/pubnub/endpoints/push/add_channels_to_push.py
+++ b/pubnub/endpoints/push/add_channels_to_push.py
@@ -1,10 +1,18 @@
+from typing import List, Union
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_CHANNEL_MISSING, PNERR_PUSH_DEVICE_MISSING, PNERROR_PUSH_TYPE_MISSING, \
     PNERR_PUSH_TOPIC_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType, PNPushType, PNPushEnvironment
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.push import PNPushAddChannelResult
 from pubnub import utils
+from pubnub.structures import Envelope
+
+
+class PNPushAddChannelResultEnvelope(Envelope):
+    result: PNPushAddChannelResult
+    status: PNStatus
 
 
 class AddChannelsToPush(Endpoint):
@@ -13,31 +21,32 @@ class AddChannelsToPush(Endpoint):
     # v2/push/sub-key/{subKey}/devices-apns2/{deviceApns2}
     ADD_PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, device_id: str = None,
+                 push_type: PNPushType = None, topic: str = None, environment: PNPushEnvironment = None):
         Endpoint.__init__(self, pubnub)
-        self._channels = None
-        self._device_id = None
-        self._push_type = None
-        self._topic = None
-        self._environment = None
+        self._channels = channels
+        self._device_id = device_id
+        self._push_type = push_type
+        self._topic = topic
+        self._environment = environment
 
-    def channels(self, channels):
+    def channels(self, channels: Union[str, List[str]]) -> 'AddChannelsToPush':
         self._channels = channels
         return self
 
-    def device_id(self, device_id):
+    def device_id(self, device_id: str) -> 'AddChannelsToPush':
         self._device_id = device_id
         return self
 
-    def push_type(self, push_type):
+    def push_type(self, push_type: PNPushType) -> 'AddChannelsToPush':
         self._push_type = push_type
         return self
 
-    def topic(self, topic):
+    def topic(self, topic: str) -> 'AddChannelsToPush':
         self._topic = topic
         return self
 
-    def environment(self, environment):
+    def environment(self, environment: PNPushEnvironment) -> 'AddChannelsToPush':
         self._environment = environment
         return self
 
@@ -84,8 +93,11 @@ class AddChannelsToPush(Endpoint):
             if not isinstance(self._topic, str) or len(self._topic) == 0:
                 raise PubNubException(pn_error=PNERR_PUSH_TOPIC_MISSING)
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNPushAddChannelResult:
         return PNPushAddChannelResult()
+
+    def sync(self) -> PNPushAddChannelResultEnvelope:
+        return PNPushAddChannelResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/push/list_push_provisions.py
+++ b/pubnub/endpoints/push/list_push_provisions.py
@@ -2,8 +2,15 @@ from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_PUSH_DEVICE_MISSING, PNERROR_PUSH_TYPE_MISSING, PNERR_PUSH_TOPIC_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType, PNPushType, PNPushEnvironment
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.push import PNPushListProvisionsResult
 from pubnub import utils
+from pubnub.structures import Envelope
+
+
+class PNPushListProvisionsResultEnvelope(Envelope):
+    result: PNPushListProvisionsResult
+    status: PNStatus
 
 
 class ListPushProvisions(Endpoint):
@@ -12,26 +19,27 @@ class ListPushProvisions(Endpoint):
     # v2/push/sub-key/{subKey}/devices-apns2/{deviceApns2}
     LIST_PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, device_id: str = None, push_type: PNPushType = None, topic: str = None,
+                 environment: PNPushEnvironment = None):
         Endpoint.__init__(self, pubnub)
-        self._device_id = None
-        self._push_type = None
-        self._topic = None
-        self._environment = None
+        self._device_id = device_id
+        self._push_type = push_type
+        self._topic = topic
+        self._environment = environment
 
-    def device_id(self, device_id):
+    def device_id(self, device_id: str) -> 'ListPushProvisions':
         self._device_id = device_id
         return self
 
-    def push_type(self, push_type):
+    def push_type(self, push_type: PNPushType) -> 'ListPushProvisions':
         self._push_type = push_type
         return self
 
-    def topic(self, topic):
+    def topic(self, topic: str) -> 'ListPushProvisions':
         self._topic = topic
         return self
 
-    def environment(self, environment):
+    def environment(self, environment: PNPushEnvironment) -> 'ListPushProvisions':
         self._environment = environment
         return self
 
@@ -73,11 +81,14 @@ class ListPushProvisions(Endpoint):
             if not isinstance(self._topic, str) or len(self._topic) == 0:
                 raise PubNubException(pn_error=PNERR_PUSH_TOPIC_MISSING)
 
-    def create_response(self, channels):
+    def create_response(self, channels) -> PNPushListProvisionsResult:
         if channels is not None and len(channels) > 0 and isinstance(channels, list):
             return PNPushListProvisionsResult(channels)
         else:
             return PNPushListProvisionsResult([])
+
+    def sync(self) -> PNPushListProvisionsResultEnvelope:
+        return PNPushListProvisionsResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/push/remove_channels_from_push.py
+++ b/pubnub/endpoints/push/remove_channels_from_push.py
@@ -1,10 +1,18 @@
+from typing import List, Union
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_CHANNEL_MISSING, PNERR_PUSH_DEVICE_MISSING, PNERROR_PUSH_TYPE_MISSING, \
     PNERR_PUSH_TOPIC_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType, PNPushType, PNPushEnvironment
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.push import PNPushRemoveChannelResult
 from pubnub import utils
+from pubnub.structures import Envelope
+
+
+class PNPushRemoveChannelResultEnvelope(Envelope):
+    result: PNPushRemoveChannelResult
+    status: PNStatus
 
 
 class RemoveChannelsFromPush(Endpoint):
@@ -13,31 +21,35 @@ class RemoveChannelsFromPush(Endpoint):
     # v2/push/sub-key/{subKey}/devices-apns2/{deviceApns2}
     REMOVE_PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, channels: Union[str, List[str]] = None, device_id: str = None,
+                 push_type: PNPushType = None, topic: str = None, environment: PNPushEnvironment = None):
         Endpoint.__init__(self, pubnub)
-        self._channels = None
-        self._device_id = None
-        self._push_type = None
-        self._topic = None
-        self._environment = None
+        self._channels = []
+        if channels:
+            utils.extend_list(self._channels, channels)
 
-    def channels(self, channels):
-        self._channels = channels
+        self._device_id = device_id
+        self._push_type = push_type
+        self._topic = topic
+        self._environment = environment
+
+    def channels(self, channels: Union[str, List[str]]) -> 'RemoveChannelsFromPush':
+        utils.extend_list(self._channels, channels)
         return self
 
-    def device_id(self, device_id):
+    def device_id(self, device_id: str) -> 'RemoveChannelsFromPush':
         self._device_id = device_id
         return self
 
-    def push_type(self, push_type):
+    def push_type(self, push_type: PNPushType) -> 'RemoveChannelsFromPush':
         self._push_type = push_type
         return self
 
-    def topic(self, topic):
+    def topic(self, topic: str) -> 'RemoveChannelsFromPush':
         self._topic = topic
         return self
 
-    def environment(self, environment):
+    def environment(self, environment: PNPushEnvironment) -> 'RemoveChannelsFromPush':
         self._environment = environment
         return self
 
@@ -82,8 +94,11 @@ class RemoveChannelsFromPush(Endpoint):
             if not isinstance(self._topic, str) or len(self._topic) == 0:
                 raise PubNubException(pn_error=PNERR_PUSH_TOPIC_MISSING)
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNPushRemoveChannelResult:
         return PNPushRemoveChannelResult()
+
+    def sync(self) -> PNPushRemoveChannelResultEnvelope:
+        return PNPushRemoveChannelResultEnvelope(self.process_sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/push/remove_device.py
+++ b/pubnub/endpoints/push/remove_device.py
@@ -2,8 +2,15 @@ from pubnub.endpoints.endpoint import Endpoint
 from pubnub.errors import PNERR_PUSH_DEVICE_MISSING, PNERROR_PUSH_TYPE_MISSING, PNERR_PUSH_TOPIC_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.enums import HttpMethod, PNOperationType, PNPushType, PNPushEnvironment
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.push import PNPushRemoveAllChannelsResult
 from pubnub import utils
+from pubnub.structures import Envelope
+
+
+class PNPushRemoveAllChannelsResultEnvelope(Envelope):
+    result: PNPushRemoveAllChannelsResult
+    status: PNStatus
 
 
 class RemoveDeviceFromPush(Endpoint):
@@ -12,26 +19,27 @@ class RemoveDeviceFromPush(Endpoint):
     # v2/push/sub-key/{subKey}/devices-apns2/{deviceApns2}/remove
     REMOVE_PATH_APNS2 = "/v2/push/sub-key/%s/devices-apns2/%s/remove"
 
-    def __init__(self, pubnub):
+    def __init__(self, pubnub, device_id: str = None, push_type: PNPushType = None, topic: str = None,
+                 environment: PNPushEnvironment = None):
         Endpoint.__init__(self, pubnub)
-        self._device_id = None
-        self._push_type = None
-        self._topic = None
-        self._environment = None
+        self._device_id = device_id
+        self._push_type = push_type
+        self._topic = topic
+        self._environment = environment
 
-    def device_id(self, device_id):
+    def device_id(self, device_id: str) -> 'RemoveDeviceFromPush':
         self._device_id = device_id
         return self
 
-    def push_type(self, push_type):
+    def push_type(self, push_type: PNPushType) -> 'RemoveDeviceFromPush':
         self._push_type = push_type
         return self
 
-    def topic(self, topic):
+    def topic(self, topic: str) -> 'RemoveDeviceFromPush':
         self._topic = topic
         return self
 
-    def environment(self, environment):
+    def environment(self, environment: PNPushEnvironment) -> 'RemoveDeviceFromPush':
         self._environment = environment
         return self
 
@@ -73,8 +81,11 @@ class RemoveDeviceFromPush(Endpoint):
             if not isinstance(self._topic, str) or len(self._topic) == 0:
                 raise PubNubException(pn_error=PNERR_PUSH_TOPIC_MISSING)
 
-    def create_response(self, envelope):
+    def create_response(self, envelope) -> PNPushRemoveAllChannelsResult:
         return PNPushRemoveAllChannelsResult()
+
+    def sync(self) -> PNPushRemoveAllChannelsResultEnvelope:
+        return PNPushRemoveAllChannelsResultEnvelope(super().sync())
 
     def is_auth_required(self):
         return True

--- a/pubnub/endpoints/signal.py
+++ b/pubnub/endpoints/signal.py
@@ -1,22 +1,32 @@
 from pubnub import utils
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.signal import PNSignalResult
+from pubnub.structures import Envelope
+
+
+class SignalResultEnvelope(Envelope):
+    result: PNSignalResult
+    status: PNStatus
 
 
 class Signal(Endpoint):
     SIGNAL_PATH = '/signal/%s/%s/0/%s/0/%s'
 
-    def __init__(self, pubnub):
-        Endpoint.__init__(self, pubnub)
-        self._channel = None
-        self._message = None
+    _channel: str
+    _message: any
 
-    def channel(self, channel):
+    def __init__(self, pubnub, channel: str = None, message: any = None):
+        Endpoint.__init__(self, pubnub)
+        self._channel = channel
+        self._message = message
+
+    def channel(self, channel) -> 'Signal':
         self._channel = str(channel)
         return self
 
-    def message(self, message):
+    def message(self, message) -> 'Signal':
         self._message = message
         return self
 
@@ -44,6 +54,9 @@ class Signal(Endpoint):
 
     def create_response(self, result):  # pylint: disable=W0221
         return PNSignalResult(result)
+
+    def sync(self) -> SignalResultEnvelope:
+        return SignalResultEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/endpoints/time.py
+++ b/pubnub/endpoints/time.py
@@ -1,6 +1,13 @@
 from pubnub.endpoints.endpoint import Endpoint
 from pubnub.enums import HttpMethod, PNOperationType
+from pubnub.models.consumer.common import PNStatus
 from pubnub.models.consumer.time import PNTimeResponse
+from pubnub.structures import Envelope
+
+
+class PNTimeResponseEnvelope(Envelope):
+    result: PNTimeResponse
+    status: PNStatus
 
 
 class Time(Endpoint):
@@ -23,6 +30,9 @@ class Time(Endpoint):
 
     def create_response(self, envelope):
         return PNTimeResponse(envelope)
+
+    def sync(self) -> PNTimeResponseEnvelope:
+        return PNTimeResponseEnvelope(super().sync())
 
     def request_timeout(self):
         return self.pubnub.config.non_subscribe_request_timeout

--- a/pubnub/pnconfiguration.py
+++ b/pubnub/pnconfiguration.py
@@ -107,6 +107,8 @@ class PNConfiguration(object):
 
     @property
     def crypto(self):
+        if self._crypto_module:
+            return self._crypto_module
         if self.crypto_instance is None:
             self._init_cryptodome()
 

--- a/pubnub/pubnub.py
+++ b/pubnub/pubnub.py
@@ -51,7 +51,6 @@ class PubNub(PubNubCore):
 
         if self.config.log_verbosity:
             print(endpoint_call_options)
-
         return self._request_handler.sync_request(platform_options, endpoint_call_options)
 
     def request_async(self, endpoint_name, endpoint_call_options, callback, cancellation_event):

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -2,6 +2,7 @@ import logging
 import time
 from warnings import warn
 from copy import deepcopy
+from typing import Optional
 from pubnub.endpoints.entities.membership.add_memberships import AddSpaceMembers, AddUserSpaces
 from pubnub.endpoints.entities.membership.update_memberships import UpdateSpaceMembers, UpdateUserSpaces
 from pubnub.endpoints.entities.membership.fetch_memberships import FetchSpaceMemberships, FetchUserMemberships
@@ -205,8 +206,11 @@ class PubNubCore:
     def where_now(self):
         return WhereNow(self)
 
-    def publish(self):
-        return Publish(self)
+    def publish(self, channel: Optional[str] = None, message: Optional[any] = None, should_store: Optional[bool] = None,
+                use_post: Optional[bool] = None, meta: Optional[any] = None, replicate: Optional[bool] = None,
+                ptto: Optional[int] = None, ttl: Optional[int] = None) -> Publish:
+        return Publish(self, channel=channel, message=message, should_store=should_store, use_post=use_post, meta=meta,
+                       replicate=replicate, ptto=ptto, ttl=ttl)
 
     def grant(self):
         warn("This method will stop working on 31th December 2024. We recommend that you use grant_token() instead.",
@@ -242,8 +246,9 @@ class PubNubCore:
     def message_counts(self):
         return MessageCount(self)
 
-    def fire(self):
-        return Fire(self)
+    def fire(self, channel: Optional[str] = None, message: Optional[any] = None, use_post: Optional[bool] = None,
+             meta: Optional[any] = None) -> Fire:
+        return Fire(self, channel=channel, message=message, use_post=use_post, meta=meta)
 
     def signal(self):
         return Signal(self)

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -94,7 +94,7 @@ logger = logging.getLogger("pubnub")
 
 class PubNubCore:
     """A base class for PubNub Python API implementations"""
-    SDK_VERSION = "8.1.0"
+    SDK_VERSION = "9.0.0"
     SDK_NAME = "PubNub-Python"
 
     TIMESTAMP_DIVIDER = 1000

--- a/pubnub/pubnub_core.py
+++ b/pubnub/pubnub_core.py
@@ -2,7 +2,7 @@ import logging
 import time
 from warnings import warn
 from copy import deepcopy
-from typing import Optional
+from typing import Dict, List, Optional, Union
 from pubnub.endpoints.entities.membership.add_memberships import AddSpaceMembers, AddUserSpaces
 from pubnub.endpoints.entities.membership.update_memberships import UpdateSpaceMembers, UpdateUserSpaces
 from pubnub.endpoints.entities.membership.fetch_memberships import FetchSpaceMemberships, FetchUserMemberships
@@ -18,10 +18,13 @@ from pubnub.endpoints.entities.user.remove_user import RemoveUser
 from pubnub.endpoints.entities.user.update_user import UpdateUser
 from pubnub.endpoints.entities.user.fetch_user import FetchUser
 from pubnub.endpoints.entities.user.fetch_users import FetchUsers
+from pubnub.enums import PNPushEnvironment, PNPushType
 from pubnub.errors import PNERR_MISUSE_OF_USER_AND_SPACE, PNERR_USER_SPACE_PAIRS_MISSING
 from pubnub.exceptions import PubNubException
 from pubnub.features import feature_flag
 from pubnub.crypto import PubNubCryptoModule
+from pubnub.models.consumer.message_actions import PNMessageAction
+from pubnub.models.consumer.objects_v2.page import PNPage
 from pubnub.models.subscription import PubNubChannel, PubNubChannelGroup, PubNubChannelMetadata, PubNubUserMetadata, \
     PNSubscriptionRegistry, PubNubSubscriptionSet
 
@@ -29,62 +32,62 @@ from abc import ABCMeta, abstractmethod
 
 from pubnub.pnconfiguration import PNConfiguration
 
-from .endpoints.objects_v2.uuid.set_uuid import SetUuid
-from .endpoints.objects_v2.channel.get_all_channels import GetAllChannels
-from .endpoints.objects_v2.channel.get_channel import GetChannel
-from .endpoints.objects_v2.channel.remove_channel import RemoveChannel
-from .endpoints.objects_v2.channel.set_channel import SetChannel
-from .endpoints.objects_v2.members.get_channel_members import GetChannelMembers
-from .endpoints.objects_v2.members.manage_channel_members import ManageChannelMembers
-from .endpoints.objects_v2.members.remove_channel_members import RemoveChannelMembers
-from .endpoints.objects_v2.members.set_channel_members import SetChannelMembers
-from .endpoints.objects_v2.memberships.get_memberships import GetMemberships
-from .endpoints.objects_v2.memberships.manage_memberships import ManageMemberships
-from .endpoints.objects_v2.memberships.remove_memberships import RemoveMemberships
-from .endpoints.objects_v2.memberships.set_memberships import SetMemberships
-from .endpoints.objects_v2.uuid.get_all_uuid import GetAllUuid
-from .endpoints.objects_v2.uuid.get_uuid import GetUuid
-from .endpoints.objects_v2.uuid.remove_uuid import RemoveUuid
-from .managers import BasePathManager, TokenManager
-from .builders import SubscribeBuilder
-from .builders import UnsubscribeBuilder
-from .endpoints.time import Time
-from .endpoints.history import History
-from .endpoints.access.audit import Audit
-from .endpoints.access.grant import Grant
-from .endpoints.access.grant_token import GrantToken
-from .endpoints.access.revoke_token import RevokeToken
-from .endpoints.channel_groups.add_channel_to_channel_group import AddChannelToChannelGroup
-from .endpoints.channel_groups.list_channels_in_channel_group import ListChannelsInChannelGroup
-from .endpoints.channel_groups.remove_channel_from_channel_group import RemoveChannelFromChannelGroup
-from .endpoints.channel_groups.remove_channel_group import RemoveChannelGroup
-from .endpoints.presence.get_state import GetState
-from .endpoints.presence.heartbeat import Heartbeat
-from .endpoints.presence.set_state import SetState
-from .endpoints.pubsub.publish import Publish
-from .endpoints.pubsub.fire import Fire
-from .endpoints.presence.here_now import HereNow
-from .endpoints.presence.where_now import WhereNow
-from .endpoints.history_delete import HistoryDelete
-from .endpoints.message_count import MessageCount
-from .endpoints.signal import Signal
-from .endpoints.fetch_messages import FetchMessages
-from .endpoints.message_actions.add_message_action import AddMessageAction
-from .endpoints.message_actions.get_message_actions import GetMessageActions
-from .endpoints.message_actions.remove_message_action import RemoveMessageAction
-from .endpoints.file_operations.list_files import ListFiles
-from .endpoints.file_operations.delete_file import DeleteFile
-from .endpoints.file_operations.get_file_url import GetFileDownloadUrl
-from .endpoints.file_operations.fetch_upload_details import FetchFileUploadS3Data
-from .endpoints.file_operations.send_file import SendFileNative
-from .endpoints.file_operations.download_file import DownloadFileNative
-from .endpoints.file_operations.publish_file_message import PublishFileMessage
+from pubnub.endpoints.objects_v2.uuid.set_uuid import SetUuid
+from pubnub.endpoints.objects_v2.channel.get_all_channels import GetAllChannels
+from pubnub.endpoints.objects_v2.channel.get_channel import GetChannel
+from pubnub.endpoints.objects_v2.channel.remove_channel import RemoveChannel
+from pubnub.endpoints.objects_v2.channel.set_channel import SetChannel
+from pubnub.endpoints.objects_v2.members.get_channel_members import GetChannelMembers
+from pubnub.endpoints.objects_v2.members.manage_channel_members import ManageChannelMembers
+from pubnub.endpoints.objects_v2.members.remove_channel_members import RemoveChannelMembers
+from pubnub.endpoints.objects_v2.members.set_channel_members import SetChannelMembers
+from pubnub.endpoints.objects_v2.memberships.get_memberships import GetMemberships
+from pubnub.endpoints.objects_v2.memberships.manage_memberships import ManageMemberships
+from pubnub.endpoints.objects_v2.memberships.remove_memberships import RemoveMemberships
+from pubnub.endpoints.objects_v2.memberships.set_memberships import SetMemberships
+from pubnub.endpoints.objects_v2.uuid.get_all_uuid import GetAllUuid
+from pubnub.endpoints.objects_v2.uuid.get_uuid import GetUuid
+from pubnub.endpoints.objects_v2.uuid.remove_uuid import RemoveUuid
+from pubnub.managers import BasePathManager, TokenManager
+from pubnub.builders import SubscribeBuilder
+from pubnub.builders import UnsubscribeBuilder
+from pubnub.endpoints.time import Time
+from pubnub.endpoints.history import History
+from pubnub.endpoints.access.audit import Audit
+from pubnub.endpoints.access.grant import Grant
+from pubnub.endpoints.access.grant_token import GrantToken
+from pubnub.endpoints.access.revoke_token import RevokeToken
+from pubnub.endpoints.channel_groups.add_channel_to_channel_group import AddChannelToChannelGroup
+from pubnub.endpoints.channel_groups.list_channels_in_channel_group import ListChannelsInChannelGroup
+from pubnub.endpoints.channel_groups.remove_channel_from_channel_group import RemoveChannelFromChannelGroup
+from pubnub.endpoints.channel_groups.remove_channel_group import RemoveChannelGroup
+from pubnub.endpoints.presence.get_state import GetState
+from pubnub.endpoints.presence.heartbeat import Heartbeat
+from pubnub.endpoints.presence.set_state import SetState
+from pubnub.endpoints.pubsub.publish import Publish
+from pubnub.endpoints.pubsub.fire import Fire
+from pubnub.endpoints.presence.here_now import HereNow
+from pubnub.endpoints.presence.where_now import WhereNow
+from pubnub.endpoints.history_delete import HistoryDelete
+from pubnub.endpoints.message_count import MessageCount
+from pubnub.endpoints.signal import Signal
+from pubnub.endpoints.fetch_messages import FetchMessages
+from pubnub.endpoints.message_actions.add_message_action import AddMessageAction
+from pubnub.endpoints.message_actions.get_message_actions import GetMessageActions
+from pubnub.endpoints.message_actions.remove_message_action import RemoveMessageAction
+from pubnub.endpoints.file_operations.list_files import ListFiles
+from pubnub.endpoints.file_operations.delete_file import DeleteFile
+from pubnub.endpoints.file_operations.get_file_url import GetFileDownloadUrl
+from pubnub.endpoints.file_operations.fetch_upload_details import FetchFileUploadS3Data
+from pubnub.endpoints.file_operations.send_file import SendFileNative
+from pubnub.endpoints.file_operations.download_file import DownloadFileNative
+from pubnub.endpoints.file_operations.publish_file_message import PublishFileMessage
 
-from .endpoints.push.add_channels_to_push import AddChannelsToPush
-from .endpoints.push.remove_channels_from_push import RemoveChannelsFromPush
-from .endpoints.push.remove_device import RemoveDeviceFromPush
-from .endpoints.push.list_push_provisions import ListPushProvisions
-from .managers import TelemetryManager
+from pubnub.endpoints.push.add_channels_to_push import AddChannelsToPush
+from pubnub.endpoints.push.remove_channels_from_push import RemoveChannelsFromPush
+from pubnub.endpoints.push.remove_device import RemoveDeviceFromPush
+from pubnub.endpoints.push.list_push_provisions import ListPushProvisions
+from pubnub.managers import TelemetryManager
 
 logger = logging.getLogger("pubnub")
 
@@ -164,25 +167,26 @@ class PubNubCore:
 
     def get_subscribed_channel_groups(self):
         self._validate_subscribe_manager_enabled()
-
         return self._subscription_manager.get_subscribed_channel_groups()
 
-    def add_channel_to_channel_group(self):
-        return AddChannelToChannelGroup(self)
+    def add_channel_to_channel_group(self, channels: Union[str, List[str]] = None,
+                                     channel_group: str = None) -> AddChannelToChannelGroup:
+        return AddChannelToChannelGroup(self, channels=channels, channel_group=channel_group)
 
-    def remove_channel_from_channel_group(self):
-        return RemoveChannelFromChannelGroup(self)
+    def remove_channel_from_channel_group(self, channels: Union[str, List[str]] = None,
+                                          channel_group: str = None) -> RemoveChannelFromChannelGroup:
+        return RemoveChannelFromChannelGroup(self, channels=channels, channel_group=channel_group)
 
-    def list_channels_in_channel_group(self):
-        return ListChannelsInChannelGroup(self)
+    def list_channels_in_channel_group(self, channel_group: str = None) -> ListChannelsInChannelGroup:
+        return ListChannelsInChannelGroup(self, channel_group=channel_group)
 
-    def remove_channel_group(self):
+    def remove_channel_group(self) -> RemoveChannelGroup:
         return RemoveChannelGroup(self)
 
-    def subscribe(self):
+    def subscribe(self) -> SubscribeBuilder:
         return SubscribeBuilder(self)
 
-    def unsubscribe(self):
+    def unsubscribe(self) -> UnsubscribeBuilder:
         return UnsubscribeBuilder(self)
 
     def unsubscribe_all(self):
@@ -191,130 +195,206 @@ class PubNubCore:
     def reconnect(self):
         return self._subscription_registry.reconnect()
 
-    def heartbeat(self):
+    def heartbeat(self) -> Heartbeat:
         return Heartbeat(self)
 
-    def set_state(self):
-        return SetState(self, self._subscription_manager)
+    def set_state(self, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                  state: Optional[Dict[str, any]] = None) -> SetState:
+        return SetState(self, self._subscription_manager, channels, channel_groups, state)
 
-    def get_state(self):
-        return GetState(self)
+    def get_state(self, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                  uuid: Optional[str] = None) -> GetState:
+        return GetState(self, channels, channel_groups, uuid)
 
-    def here_now(self):
-        return HereNow(self)
+    def here_now(self, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                 include_state: bool = False, include_uuids: bool = True) -> HereNow:
+        return HereNow(self, channels, channel_groups, include_state, include_uuids)
 
-    def where_now(self):
-        return WhereNow(self)
+    def where_now(self, user_id: Optional[str] = None):
+        return WhereNow(self, user_id)
 
-    def publish(self, channel: Optional[str] = None, message: Optional[any] = None, should_store: Optional[bool] = None,
+    def publish(self, channel: str = None, message: any = None, should_store: Optional[bool] = None,
                 use_post: Optional[bool] = None, meta: Optional[any] = None, replicate: Optional[bool] = None,
                 ptto: Optional[int] = None, ttl: Optional[int] = None) -> Publish:
+        """ Sends a message to all channel subscribers. A successfully published message is replicated across PubNub's
+        points of presence and sent simultaneously to all subscribed clients on a channel.
+        """
         return Publish(self, channel=channel, message=message, should_store=should_store, use_post=use_post, meta=meta,
                        replicate=replicate, ptto=ptto, ttl=ttl)
 
     def grant(self):
+        """ Deprecated. Use grant_token instead """
         warn("This method will stop working on 31th December 2024. We recommend that you use grant_token() instead.",
              DeprecationWarning, stacklevel=2)
         return Grant(self)
 
-    def grant_token(self):
-        return GrantToken(self)
+    def grant_token(self, channels: Union[str, List[str]] = None, channel_groups: Union[str, List[str]] = None,
+                    users: Union[str, List[str]] = None, spaces: Union[str, List[str]] = None,
+                    authorized_user_id: str = None, ttl: Optional[int] = None, meta: Optional[any] = None):
+        return GrantToken(self, channels=channels, channel_groups=channel_groups, users=users, spaces=spaces,
+                          authorized_user_id=authorized_user_id, ttl=ttl, meta=meta)
 
-    def revoke_token(self, token):
+    def revoke_token(self, token: str) -> RevokeToken:
         return RevokeToken(self, token)
 
     def audit(self):
+        """ Deprecated """
         warn("This method will stop working on 31th December 2024.", DeprecationWarning, stacklevel=2)
         return Audit(self)
 
     # Push Related methods
-    def list_push_channels(self):
-        return ListPushProvisions(self)
+    def list_push_channels(self, device_id: str = None, push_type: PNPushType = None, topic: str = None,
+                           environment: PNPushEnvironment = None) -> ListPushProvisions:
+        return ListPushProvisions(self, device_id=device_id, push_type=push_type, topic=topic, environment=environment)
 
-    def add_channels_to_push(self):
-        return AddChannelsToPush(self)
+    def add_channels_to_push(self, channels: Union[str, List[str]], device_id: str = None, push_type: PNPushType = None,
+                             topic: str = None, environment: PNPushEnvironment = None) -> AddChannelsToPush:
+        return AddChannelsToPush(self, channels=channels, device_id=device_id, push_type=push_type, topic=topic,
+                                 environment=environment)
 
-    def remove_channels_from_push(self):
-        return RemoveChannelsFromPush(self)
+    def remove_channels_from_push(self, channels: Union[str, List[str]] = None, device_id: str = None,
+                                  push_type: PNPushType = None, topic: str = None,
+                                  environment: PNPushEnvironment = None) -> RemoveChannelsFromPush:
+        return RemoveChannelsFromPush(self, channels=channels, device_id=device_id, push_type=push_type, topic=topic,
+                                      environment=environment)
 
-    def remove_device_from_push(self):
-        return RemoveDeviceFromPush(self)
+    def remove_device_from_push(self, device_id: str = None, push_type: PNPushType = None, topic: str = None,
+                                environment: PNPushEnvironment = None) -> RemoveDeviceFromPush:
+        return RemoveDeviceFromPush(self, device_id=device_id, push_type=push_type, topic=topic,
+                                    environment=environment)
 
     def history(self):
         return History(self)
 
-    def message_counts(self):
-        return MessageCount(self)
+    def message_counts(self, channels: Union[str, List[str]] = None,
+                       channels_timetoken: Union[str, List[str]] = None) -> MessageCount:
+        return MessageCount(self, channels=channels, channels_timetoken=channels_timetoken)
 
-    def fire(self, channel: Optional[str] = None, message: Optional[any] = None, use_post: Optional[bool] = None,
+    def fire(self, channel: str = None, message: any = None, use_post: Optional[bool] = None,
              meta: Optional[any] = None) -> Fire:
         return Fire(self, channel=channel, message=message, use_post=use_post, meta=meta)
 
-    def signal(self):
-        return Signal(self)
+    def signal(self, channel: str = None, message: any = None) -> Signal:
+        return Signal(self, channel=channel, message=message)
 
-    def set_uuid_metadata(self):
-        return SetUuid(self)
+    def set_uuid_metadata(self, uuid: str = None, include_custom: bool = None, custom: dict = None,
+                          include_status: bool = True, include_type: bool = True, status: str = None, type: str = None,
+                          name: str = None, email: str = None, external_id: str = None,
+                          profile_url: str = None) -> SetUuid:
+        return SetUuid(self, uuid=uuid, include_custom=include_custom, custom=custom, include_status=include_status,
+                       include_type=include_type, status=status, type=type, name=name, email=email,
+                       external_id=external_id, profile_url=profile_url)
 
-    def get_uuid_metadata(self):
-        return GetUuid(self)
+    def get_uuid_metadata(self, uuud: str = None, include_custom: bool = None, include_status: bool = True,
+                          include_type: bool = True) -> GetUuid:
+        return GetUuid(self, uuid=uuud, include_custom=include_custom, include_status=include_status,
+                       include_type=include_type)
 
-    def remove_uuid_metadata(self):
-        return RemoveUuid(self)
+    def remove_uuid_metadata(self, uuid: str = None) -> RemoveUuid:
+        return RemoveUuid(self, uuid=uuid)
 
-    def get_all_uuid_metadata(self):
-        return GetAllUuid(self)
+    def get_all_uuid_metadata(self, include_custom: bool = None, include_status: bool = True, include_type: bool = True,
+                              limit: int = None, filter: str = None, include_total_count: bool = None,
+                              sort_keys: list = None) -> GetAllUuid:
+        return GetAllUuid(self, include_custom=include_custom, include_status=include_status, include_type=include_type,
+                          limit=limit, filter=filter, include_total_count=include_total_count, sort_keys=sort_keys)
 
-    def set_channel_metadata(self):
-        return SetChannel(self)
+    def set_channel_metadata(self, channel: str = None, custom: dict = None, include_custom: bool = False,
+                             include_status: bool = True, include_type: bool = True, name: str = None,
+                             description: str = None, status: str = None, type: str = None) -> SetChannel:
+        return SetChannel(self, channel=channel, custom=custom, include_custom=include_custom,
+                          include_status=include_status, include_type=include_type, name=name, description=description,
+                          status=status, type=type)
 
-    def get_channel_metadata(self):
-        return GetChannel(self)
+    def get_channel_metadata(self, channel: str = None, include_custom: bool = False, include_status: bool = True,
+                             include_type: bool = True) -> GetChannel:
+        return GetChannel(self, channel=channel, include_custom=include_custom, include_status=include_status,
+                          include_type=include_type)
 
-    def remove_channel_metadata(self):
-        return RemoveChannel(self)
+    def remove_channel_metadata(self, channel: str = None) -> RemoveChannel:
+        return RemoveChannel(self, channel=channel)
 
-    def get_all_channel_metadata(self):
-        return GetAllChannels(self)
+    def get_all_channel_metadata(self, include_custom=False, include_status=True, include_type=True,
+                                 limit: int = None, filter: str = None, include_total_count: bool = None,
+                                 sort_keys: list = None, page: PNPage = None) -> GetAllChannels:
+        return GetAllChannels(self, include_custom=include_custom, include_status=include_status,
+                              include_type=include_type, limit=limit, filter=filter,
+                              include_total_count=include_total_count, sort_keys=sort_keys, page=page)
 
-    def set_channel_members(self):
-        return SetChannelMembers(self)
+    def set_channel_members(self, channel: str = None, uuids: List[str] = None, include_custom: bool = None,
+                            limit: int = None, filter: str = None, include_total_count: bool = None,
+                            sort_keys: list = None, page: PNPage = None) -> SetChannelMembers:
+        return SetChannelMembers(self, channel=channel, uuids=uuids, include_custom=include_custom, limit=limit,
+                                 filter=filter, include_total_count=include_total_count, sort_keys=sort_keys, page=page)
 
-    def get_channel_members(self):
-        return GetChannelMembers(self)
+    def get_channel_members(self, channel: str = None, include_custom: bool = None, limit: int = None,
+                            filter: str = None, include_total_count: bool = None, sort_keys: list = None,
+                            page: PNPage = None) -> GetChannelMembers:
+        return GetChannelMembers(self, channel=channel, include_custom=include_custom, limit=limit, filter=filter,
+                                 include_total_count=include_total_count, sort_keys=sort_keys, page=page)
 
-    def remove_channel_members(self):
-        return RemoveChannelMembers(self)
+    def remove_channel_members(self, channel: str = None, uuids: List[str] = None, include_custom: bool = None,
+                               limit: int = None, filter: str = None, include_total_count: bool = None,
+                               sort_keys: list = None, page: PNPage = None) -> RemoveChannelMembers:
+        return RemoveChannelMembers(self, channel=channel, uuids=uuids, include_custom=include_custom, limit=limit,
+                                    filter=filter, include_total_count=include_total_count, sort_keys=sort_keys,
+                                    page=page)
 
-    def manage_channel_members(self):
-        return ManageChannelMembers(self)
+    def manage_channel_members(self, channel: str = None, uuids_to_set: List[str] = None,
+                               uuids_to_remove: List[str] = None, include_custom: bool = None, limit: int = None,
+                               filter: str = None, include_total_count: bool = None, sort_keys: list = None,
+                               page: PNPage = None) -> ManageChannelMembers:
+        return ManageChannelMembers(self, channel=channel, uuids_to_set=uuids_to_set, uuids_to_remove=uuids_to_remove,
+                                    include_custom=include_custom, limit=limit, filter=filter,
+                                    include_total_count=include_total_count, sort_keys=sort_keys, page=page)
 
-    def set_memberships(self):
-        return SetMemberships(self)
+    def set_memberships(self, uuid: str = None, channel_memberships: List[str] = None, include_custom: bool = False,
+                        limit: int = None, filter: str = None, include_total_count: bool = None, sort_keys: list = None,
+                        page: PNPage = None) -> SetMemberships:
+        return SetMemberships(self, uuid=uuid, channel_memberships=channel_memberships, include_custom=include_custom,
+                              limit=limit, filter=filter, include_total_count=include_total_count, sort_keys=sort_keys,
+                              page=page)
 
-    def get_memberships(self):
-        return GetMemberships(self)
+    def get_memberships(self, uuid: str = None, include_custom: bool = False, limit: int = None, filter: str = None,
+                        include_total_count: bool = None, sort_keys: list = None, page: PNPage = None):
+        return GetMemberships(self, uuid=uuid, include_custom=include_custom, limit=limit, filter=filter,
+                              include_total_count=include_total_count, sort_keys=sort_keys, page=page)
 
-    def manage_memberships(self):
-        return ManageMemberships(self)
+    def manage_memberships(self, uuid: str = None, channel_memberships_to_set: List[str] = None,
+                           channel_memberships_to_remove: List[str] = None, include_custom: bool = False,
+                           limit: int = None, filter: str = None, include_total_count: bool = None,
+                           sort_keys: list = None, page: PNPage = None) -> ManageMemberships:
+        return ManageMemberships(self, uuid=uuid, channel_memberships_to_set=channel_memberships_to_set,
+                                 channel_memberships_to_remove=channel_memberships_to_remove,
+                                 include_custom=include_custom, limit=limit, filter=filter,
+                                 include_total_count=include_total_count, sort_keys=sort_keys, page=page)
 
-    def fetch_messages(self):
-        return FetchMessages(self)
+    def fetch_messages(self, channels: Union[str, List[str]] = None, start: int = None, end: int = None,
+                       count: int = None, include_meta: bool = None, include_message_actions: bool = None,
+                       include_message_type: bool = None, include_uuid: bool = None,
+                       decrypt_messages: bool = False) -> FetchMessages:
+        return FetchMessages(self, channels=channels, start=start, end=end, count=count, include_meta=include_meta,
+                             include_message_actions=include_message_actions, include_message_type=include_message_type,
+                             include_uuid=include_uuid, decrypt_messages=decrypt_messages)
 
-    def add_message_action(self):
-        return AddMessageAction(self)
+    def add_message_action(self, channel: str = None, message_action: PNMessageAction = None):
+        return AddMessageAction(self, channel=channel, message_action=message_action)
 
-    def get_message_actions(self):
-        return GetMessageActions(self)
+    def get_message_actions(self, channel: str = None, start: str = None, end: str = None,
+                            limit: str = None) -> GetMessageActions:
+        return GetMessageActions(self, channel=channel, start=start, end=end, limit=limit)
 
-    def remove_message_action(self):
-        return RemoveMessageAction(self)
+    def remove_message_action(self, channel: str = None, message_timetoken: int = None,
+                              action_timetoken: int = None) -> RemoveMessageAction:
+        return RemoveMessageAction(self, channel=channel, message_timetoken=message_timetoken,
+                                   action_timetoken=action_timetoken)
 
-    def time(self):
+    def time(self) -> Time:
         return Time(self)
 
-    def delete_messages(self):
-        return HistoryDelete(self)
+    def delete_messages(self, channel: str = None, start: Optional[int] = None,
+                        end: Optional[int] = None) -> HistoryDelete:
+        return HistoryDelete(self, channel=channel, start=start, end=end)
 
     def parse_token(self, token):
         return self._token_manager.parse_token(token)
@@ -329,7 +409,7 @@ class PubNubCore:
         if not self.sdk_platform():
             return SendFileNative(self)
         elif "Asyncio" in self.sdk_platform():
-            from .endpoints.file_operations.send_file_asyncio import AsyncioSendFile
+            from pubnub.endpoints.file_operations.send_file_asyncio import AsyncioSendFile
             return AsyncioSendFile(self)
         else:
             raise NotImplementedError
@@ -338,24 +418,24 @@ class PubNubCore:
         if not self.sdk_platform():
             return DownloadFileNative(self)
         elif "Asyncio" in self.sdk_platform():
-            from .endpoints.file_operations.download_file_asyncio import DownloadFileAsyncio
+            from pubnub.endpoints.file_operations.download_file_asyncio import DownloadFileAsyncio
             return DownloadFileAsyncio(self)
         else:
             raise NotImplementedError
 
-    def list_files(self):
-        return ListFiles(self)
+    def list_files(self, channel: str = None) -> ListFiles:
+        return ListFiles(self, channel=channel)
 
-    def get_file_url(self):
-        return GetFileDownloadUrl(self)
+    def get_file_url(self, channel: str = None, file_name: str = None, file_id: str = None) -> GetFileDownloadUrl:
+        return GetFileDownloadUrl(self, channel=channel, file_name=file_name, file_id=file_id)
 
-    def delete_file(self):
-        return DeleteFile(self)
+    def delete_file(self, channel: str = None, file_name: str = None, file_id: str = None) -> DeleteFile:
+        return DeleteFile(self, channel=channel, file_name=file_name, file_id=file_id)
 
-    def _fetch_file_upload_s3_data(self):
+    def _fetch_file_upload_s3_data(self) -> FetchFileUploadS3Data:
         return FetchFileUploadS3Data(self)
 
-    def publish_file_message(self):
+    def publish_file_message(self) -> PublishFileMessage:
         return PublishFileMessage(self)
 
     def decrypt(self, cipher_key, file):

--- a/pubnub/structures.py
+++ b/pubnub/structures.py
@@ -91,6 +91,10 @@ class ResponseInfo(object):
 
 
 class Envelope(object):
-    def __init__(self, result, status):
-        self.result = result
-        self.status = status
+    def __init__(self, result, status=None):
+        if isinstance(result, Envelope):
+            self.result = result.result
+            self.status = result.status
+        else:
+            self.result = result
+            self.status = status

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pubnub',
-    version='8.1.0',
+    version='9.0.0',
     description='PubNub Real-time push service in the cloud',
     author='PubNub',
     author_email='support@pubnub.com',


### PR DESCRIPTION
feat: Reconnecting with exponential backoff by default.

Automatic reconnecting for subscribe with exponential backoff is now enabled by default.

BREAKING CHANGES: Modifies Default Behavior of SDK

feat: Access manager v2 deprecation

Access manager v2 endpoints (grant and audit) will no longer be supported after December 31, 2024, and will be removed without further notice. Refer to the documentation to learn more.

feat: Configuration Becomes Immutable
 
Once used to instantiate PubNub, the configuration object (PNConfiguration instance) becomes immutable. You will receive exceptions if you rely on modifying the configuration after the PubNub instance is created. Refer to the documentation to learn more.

BREAKING CHANGES: Modifies Default Behavior of SDK

style: Type hints and named parameters

Type hints for parameters and return values are now added to provide a better developer experience.

style: Named parameters for endpoints

All endpoints are now accessible through the builder pattern and named parameters, providing a more flexible experience suitable for custom solutions.