### PR TITLE
Remove negotiated HTTP version from DEBUG logs

### DIFF
--- a/pubnub/request_handlers/async_aiohttp.py
+++ b/pubnub/request_handlers/async_aiohttp.py
@@ -173,7 +173,7 @@ class AsyncAiohttpRequestHandler(BaseRequestHandler):
         else:
             data = "N/A"
 
-        logger.debug("[%s %s] %s" % (options.operation_type, response_info.http_version, data))
+        logger.debug(data)
 
         if response.status not in (200, 307, 204):
 

--- a/pubnub/request_handlers/async_httpx.py
+++ b/pubnub/request_handlers/async_httpx.py
@@ -226,7 +226,7 @@ class AsyncHttpxRequestHandler(BaseRequestHandler):
         else:
             data = "N/A"
 
-        logger.debug("[%s %s] %s" % (options.operation_type, response_info.http_version, data))
+        logger.debug(data)
 
         if response.status_code not in (200, 307, 204):
 

--- a/pubnub/request_handlers/httpx.py
+++ b/pubnub/request_handlers/httpx.py
@@ -434,15 +434,15 @@ class HttpxRequestHandler(BaseRequestHandler):
 
         try:
             res = session.request(**args)
-
+            # Safely access response text - read content first for streaming responses
             try:
-                logger.debug("[%s %s] %s" % (e_options.operation_type, res.http_version, res.text))
+                logger.debug("GOT %s" % res.text)
             except httpx.ResponseNotRead:
-                content = res.content.decode('utf-8', errors='ignore')
-                logger.debug("[%s %s] %s" % (e_options.operation_type, res.http_version, content))
+                # For streaming responses, we need to read first
+                logger.debug("GOT %s" % res.content.decode('utf-8', errors='ignore'))
             except Exception as e:
-                msg = "(content access failed: %s)" % str(e)
-                logger.debug("[%s %s] %s" % (e_options.operation_type, res.http_version, msg))
+                # Fallback logging in case of any response reading issues
+                logger.debug("GOT response (content access failed: %s)" % str(e))
 
         except httpx.ConnectError as e:
             if use_watchdog and self._watchdog.triggered:

--- a/pubnub/request_handlers/requests.py
+++ b/pubnub/request_handlers/requests.py
@@ -272,12 +272,7 @@ class RequestsRequestHandler(BaseRequestHandler):
 
         try:
             res = self.session.request(**args)
-            http_ver = (
-                f"HTTP/{res.raw.version // 10}.{res.raw.version % 10}"
-                if res.raw and res.raw.version else "unknown"
-            )
-            logger.debug("[%s %s] %s" % (e_options.operation_type, http_ver, res.text))
-
+            logger.debug("GOT %s" % res.text)
         except requests.exceptions.ConnectionError as e:
             raise PubNubException(
                 pn_error=PNERR_CONNECTION_ERROR,


### PR DESCRIPTION
fix: remove negotiated HTTP version from DEBUG logs